### PR TITLE
Pr: Allow filtering with mutiple query-parameters for /matches & /scores

### DIFF
--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/RankListResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/RankListResource.java
@@ -25,6 +25,6 @@ public interface RankListResource {
     })
     @Path(ID_PATH)
     @GET
-    public Response getTopScoresBygame(@PathParam("gameId") Long gameId, @QueryParam("top") @DefaultValue("50") int top);
+    public Response getTopScoresBygame(@PathParam("gameId") Long gameId, @QueryParam("top") @DefaultValue("50") int top, @QueryParam("includeDeactivated") Boolean includeDeactivated);
 
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
@@ -12,6 +12,8 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import java.util.Optional;
+
 import static com.gepardec.rest.api.ScoreResource.BASE_SCORE_PATH;
 
 
@@ -42,8 +44,10 @@ public interface ScoreResource {
             @ApiResponse(responseCode = "204", description = "No Content - No scores were found")
     })
     @GET()
-    public Response getScores(@QueryParam("min") @DefaultValue("0") double minScore,
-                              @QueryParam("max") @DefaultValue("0") double maxScore);
+    public Response getScores(@QueryParam("min") Optional<Double> minScore,
+                              @QueryParam("max") Optional<Double> maxScore,
+                              @QueryParam("user") Optional<Long> userId,
+                              @QueryParam("game") Optional<Long> gameId);
 
     @Operation(summary = "Get Scores by id", description = "Returns list of scores")
     @ApiResponses(value = {

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
@@ -23,8 +23,6 @@ import static com.gepardec.rest.api.ScoreResource.BASE_SCORE_PATH;
 public interface ScoreResource {
     public static final String BASE_SCORE_PATH = "scores";
     public static final String ID_PATH = "{id}";
-    public static final String USER_ID_PATH = "user/"+ ID_PATH;
-    public static final String GAME_ID_PATH = "game/"+ ID_PATH;
     public static final String SCOREPOINTS_PATH = "scorepoints/{points}";
 
     //Only temporary for testing
@@ -47,7 +45,8 @@ public interface ScoreResource {
     public Response getScores(@QueryParam("min") Double minScore,
                               @QueryParam("max") Double maxScore,
                               @QueryParam("user") Long userId,
-                              @QueryParam("game") Long gameId);
+                              @QueryParam("game") Long gameId,
+                              @QueryParam("includeDeactivated") Boolean includeDeactivated);
 
     @Operation(summary = "Get Scores by id", description = "Returns list of scores")
     @ApiResponses(value = {
@@ -63,6 +62,6 @@ public interface ScoreResource {
     })
     @Path( SCOREPOINTS_PATH)
     @GET
-    public Response getScoreByScorePoints(@PathParam("points") double points);
+    public Response getScoreByScorePoints(@PathParam("points") double points, @QueryParam("includeDeactivated") Boolean includeDeactivated);
 
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
@@ -44,10 +44,10 @@ public interface ScoreResource {
             @ApiResponse(responseCode = "204", description = "No Content - No scores were found")
     })
     @GET()
-    public Response getScores(@QueryParam("min") Optional<Double> minScore,
-                              @QueryParam("max") Optional<Double> maxScore,
-                              @QueryParam("user") Optional<Long> userId,
-                              @QueryParam("game") Optional<Long> gameId);
+    public Response getScores(@QueryParam("min") Double minScore,
+                              @QueryParam("max") Double maxScore,
+                              @QueryParam("user") Long userId,
+                              @QueryParam("game") Long gameId);
 
     @Operation(summary = "Get Scores by id", description = "Returns list of scores")
     @ApiResponses(value = {

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
@@ -63,24 +63,6 @@ public interface ScoreResource {
             @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
             @ApiResponse(responseCode = "204", description = "No Content - No scores were found")
     })
-    @Path(USER_ID_PATH )
-    @GET
-    public Response getScoreByUser(@PathParam("id") Long id);
-
-    @Operation(summary = "Get Scores by gameId", description = "Returns list of scores")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
-            @ApiResponse(responseCode = "204", description = "No Content - No scores were found")
-    })
-    @Path(GAME_ID_PATH)
-    @GET
-    public Response getScoreByGame(@PathParam("id") Long gameId);
-
-    @Operation(summary = "Get Scores by Scorepoints", description = "Returns list of scores")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
-            @ApiResponse(responseCode = "204", description = "No Content - No scores were found")
-    })
     @Path( SCOREPOINTS_PATH)
     @GET
     public Response getScoreByScorePoints(@PathParam("points") double points);

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/ScoreResource.java
@@ -38,7 +38,7 @@ public interface ScoreResource {
     public Response createScore(@Valid CreateScoreCommand createScoreCommand);
     //-------------------------------
 
-    @Operation(summary = "Get all Scores (optional: MinMax ScorePoints)", description = "Returns list of scores")
+    @Operation(summary = "Get all Scores (optional filter: min, max, user & game)", description = "Returns list of scores")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
             @ApiResponse(responseCode = "204", description = "No Content - No scores were found")
@@ -52,7 +52,6 @@ public interface ScoreResource {
     @Operation(summary = "Get Scores by id", description = "Returns list of scores")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
-            @ApiResponse(responseCode = "204", description = "No Content - No scores were found")
     })
     @Path(ID_PATH)
     @GET
@@ -61,7 +60,6 @@ public interface ScoreResource {
     @Operation(summary = "Get Scores by userId", description = "Returns list of scores")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
-            @ApiResponse(responseCode = "204", description = "No Content - No scores were found")
     })
     @Path( SCOREPOINTS_PATH)
     @GET

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/UserResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/UserResource.java
@@ -57,7 +57,6 @@ public interface UserResource {
     @Operation(summary = "Get all users including the deleted User", description = "Returns a list of users including deleted users")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
-            @ApiResponse(responseCode = "204", description = "No Content - No users were found")
     })
     @Path("/includeDeleted")
     @GET
@@ -66,7 +65,6 @@ public interface UserResource {
     @Operation(summary = "Get User by id", description = "Returns user by id")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
-            @ApiResponse(responseCode = "204", description = "No Content - The user was not found")
     })
     @Path("{id}")
     @GET

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/MatchResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/MatchResourceImpl.java
@@ -28,20 +28,9 @@ public class MatchResourceImpl implements MatchResource {
   @Override
   public Response getMatches(Optional<Long> gameId, Optional<Long> userId) {
 
-    if (gameId.isPresent()) {
-      logger.info("Getting all Matches with GameID: %s".formatted(gameId.get()));
+    if (gameId.isPresent() || userId.isPresent()) {
       return Response.ok()
-          .entity(matchService.findMatchsByGameId(gameId.get())
-              .stream()
-              .map(MatchRestDto::new)
-              .toList())
-          .build();
-    }
-
-    if (userId.isPresent()) {
-      logger.info("Getting all Matchess with UserID: %s".formatted(userId.get()));
-      return Response.ok().
-          entity(matchService.findMatchByUserId(userId.get())
+          .entity(matchService.findMatchesByUserIdAndGameId(userId, gameId)
               .stream()
               .map(MatchRestDto::new)
               .toList())
@@ -55,6 +44,7 @@ public class MatchResourceImpl implements MatchResource {
             .map(MatchRestDto::new)
             .toList())
         .build();
+
   }
 
 

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/RankListResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/RankListResourceImpl.java
@@ -14,9 +14,9 @@ public class RankListResourceImpl implements RankListResource {
 
 
     @Override
-    public Response getTopScoresBygame(Long gameId, int top) {
-        return scoreService.findTopScoresByGame(gameId,top).stream().map(ScoreRestDto::new).toList().isEmpty()
+    public Response getTopScoresBygame(Long gameId, int top, Boolean includeDeactivated) {
+        return scoreService.findTopScoresByGame(gameId,top, includeDeactivated).stream().map(ScoreRestDto::new).toList().isEmpty()
                 ? Response.status(Response.Status.NO_CONTENT).build()
-                : Response.ok().entity(scoreService.findTopScoresByGame(gameId,top).stream().map(ScoreRestDto::new).toList()).build();
+                : Response.ok().entity(scoreService.findTopScoresByGame(gameId,top, includeDeactivated).stream().map(ScoreRestDto::new).toList()).build();
     }
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/RankListResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/RankListResourceImpl.java
@@ -15,8 +15,8 @@ public class RankListResourceImpl implements RankListResource {
 
     @Override
     public Response getTopScoresBygame(Long gameId, int top) {
-        return scoreService.findTopScoreByGame(gameId,top).stream().map(ScoreRestDto::new).toList().isEmpty()
+        return scoreService.findTopScoresByGame(gameId,top).stream().map(ScoreRestDto::new).toList().isEmpty()
                 ? Response.status(Response.Status.NO_CONTENT).build()
-                : Response.ok().entity(scoreService.findTopScoreByGame(gameId,top).stream().map(ScoreRestDto::new).toList()).build();
+                : Response.ok().entity(scoreService.findTopScoresByGame(gameId,top).stream().map(ScoreRestDto::new).toList()).build();
     }
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
@@ -35,22 +35,6 @@ public class ScoreResourceImpl implements ScoreResource {
     }
 
     @Override
-    public Response getScoreByUser(Long userId) {
-        return scoreService.findScoreByUser(userId).stream().map(ScoreRestDto::new).toList().isEmpty()
-                ? Response.status(Response.Status.NO_CONTENT).build()
-                : Response.ok().entity(scoreService.findScoreByUser(userId).stream().map(ScoreRestDto::new).toList()).build();
-
-    }
-
-    @Override
-    public Response getScoreByGame(Long gameId) {
-        return scoreService.findScoreByGame(gameId).stream().map(ScoreRestDto::new).toList().isEmpty()
-                ? Response.status(Response.Status.NO_CONTENT).build()
-                : Response.ok().entity(scoreService.findScoreByGame(gameId).stream().map(ScoreRestDto::new).toList()).build();
-
-    }
-
-    @Override
     public Response getScoreByScorePoints(double points) {
         return scoreService.findScoreByScorePoints(points).stream().map(ScoreRestDto::new).toList().isEmpty()
                 ? Response.status(Response.Status.NO_CONTENT).build()

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
@@ -9,6 +9,8 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
+import java.util.Optional;
+
 @RequestScoped
 public class ScoreResourceImpl implements ScoreResource {
 
@@ -18,16 +20,11 @@ public class ScoreResourceImpl implements ScoreResource {
     private RestMapper mapper;
 
     @Override
-    public Response getScores(double minScore, double maxScore) {
-        if (minScore == 0 && maxScore == 0) {
-            return scoreService.findAllScores().stream().map(ScoreRestDto::new).toList().isEmpty()
-                    ? Response.status(Response.Status.NO_CONTENT).build()
-                    : Response.ok().entity(scoreService.findAllScores().stream().map(ScoreRestDto::new).toList()).build();
-        } else {
-            return scoreService.findScoreByMinMaxScorePoints(minScore,maxScore).stream().map(ScoreRestDto::new).toList().isEmpty()
-                    ? Response.status(Response.Status.NO_CONTENT).build()
-                    : Response.ok().entity(scoreService.findScoreByMinMaxScorePoints(minScore,maxScore).stream().map(ScoreRestDto::new).toList()).build();
-        }
+    public Response getScores(Optional<Double> minPoints, Optional<Double> maxPoints, Optional<Long> userId, Optional<Long> gameId) {
+        return scoreService.findScoresFilter(minPoints,maxPoints, userId,gameId).stream().map(ScoreRestDto::new).toList().isEmpty()
+                ? Response.status(Response.Status.NO_CONTENT).build()
+                : Response.ok().entity(scoreService.findScoresFilter(minPoints,maxPoints, userId,gameId).stream().map(ScoreRestDto::new).toList()).build();
+
     }
 
     @Override

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
@@ -4,6 +4,7 @@ import com.gepardec.core.services.ScoreService;
 import com.gepardec.rest.api.ScoreResource;
 import com.gepardec.rest.model.command.CreateScoreCommand;
 import com.gepardec.rest.model.dto.ScoreRestDto;
+import com.gepardec.rest.model.dto.UserRestDto;
 import com.gepardec.rest.model.mapper.RestMapper;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -21,9 +22,11 @@ public class ScoreResourceImpl implements ScoreResource {
 
     @Override
     public Response getScores(Optional<Double> minPoints, Optional<Double> maxPoints, Optional<Long> userId, Optional<Long> gameId) {
-        return scoreService.findScoresFilter(minPoints,maxPoints, userId,gameId).stream().map(ScoreRestDto::new).toList().isEmpty()
-                ? Response.status(Response.Status.NO_CONTENT).build()
-                : Response.ok().entity(scoreService.findScoresFilter(minPoints,maxPoints, userId,gameId).stream().map(ScoreRestDto::new).toList()).build();
+        return Response.ok(scoreService.findScoresFilter(minPoints,maxPoints, userId,gameId)
+                        .stream()
+                        .map(ScoreRestDto::new)
+                        .toList())
+                .build();
 
     }
 
@@ -36,9 +39,11 @@ public class ScoreResourceImpl implements ScoreResource {
 
     @Override
     public Response getScoreByScorePoints(double points) {
-        return scoreService.findScoreByScorePoints(points).stream().map(ScoreRestDto::new).toList().isEmpty()
-                ? Response.status(Response.Status.NO_CONTENT).build()
-                : Response.ok().entity(scoreService.findScoreByScorePoints(points).stream().map(ScoreRestDto::new).toList()).build();
+        return Response.ok(scoreService.findScoreByScorePoints(points)
+                        .stream()
+                        .map(ScoreRestDto::new)
+                        .toList())
+                .build();
     }
 
     //Only temporary for testing

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
@@ -20,8 +20,8 @@ public class ScoreResourceImpl implements ScoreResource {
     private RestMapper mapper;
 
     @Override
-    public Response getScores(Double minPoints, Double maxPoints, Long userId, Long gameId) {
-        return Response.ok(scoreService.filterScores(minPoints,maxPoints, userId,gameId)
+    public Response getScores(Double minPoints, Double maxPoints, Long userId, Long gameId,Boolean includeDeactivated) {
+        return Response.ok(scoreService.filterScores(minPoints,maxPoints, userId,gameId,includeDeactivated)
                         .stream()
                         .map(ScoreRestDto::new)
                         .toList())
@@ -36,8 +36,8 @@ public class ScoreResourceImpl implements ScoreResource {
     }
 
     @Override
-    public Response getScoreByScorePoints(double points) {
-        return Response.ok(scoreService.findScoreByScoresPoints(points)
+    public Response getScoreByScorePoints(double points, Boolean includeDeactivated) {
+        return Response.ok(scoreService.findScoreByScoresPoints(points, includeDeactivated)
                         .stream()
                         .map(ScoreRestDto::new)
                         .toList())

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
@@ -20,13 +20,12 @@ public class ScoreResourceImpl implements ScoreResource {
     private RestMapper mapper;
 
     @Override
-    public Response getScores(Optional<Double> minPoints, Optional<Double> maxPoints, Optional<Long> userId, Optional<Long> gameId) {
-        return Response.ok(scoreService.findScoresFilter(minPoints,maxPoints, userId,gameId)
+    public Response getScores(Double minPoints, Double maxPoints, Long userId, Long gameId) {
+        return Response.ok(scoreService.filterScores(minPoints,maxPoints, userId,gameId)
                         .stream()
                         .map(ScoreRestDto::new)
                         .toList())
                 .build();
-
     }
 
     @Override

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/ScoreResourceImpl.java
@@ -4,7 +4,6 @@ import com.gepardec.core.services.ScoreService;
 import com.gepardec.rest.api.ScoreResource;
 import com.gepardec.rest.model.command.CreateScoreCommand;
 import com.gepardec.rest.model.dto.ScoreRestDto;
-import com.gepardec.rest.model.dto.UserRestDto;
 import com.gepardec.rest.model.mapper.RestMapper;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -39,7 +38,7 @@ public class ScoreResourceImpl implements ScoreResource {
 
     @Override
     public Response getScoreByScorePoints(double points) {
-        return Response.ok(scoreService.findScoreByScorePoints(points)
+        return Response.ok(scoreService.findScoreByScoresPoints(points)
                         .stream()
                         .map(ScoreRestDto::new)
                         .toList())

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/UserResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/UserResourceImpl.java
@@ -36,23 +36,27 @@ public class UserResourceImpl implements UserResource {
     @Override
     public Response getUser(Long id){
         return userService.findUserById(id).map(UserRestDto::new).map(Response::ok)
-                .orElseGet(() ->  Response.status(Status.NO_CONTENT)).build();
+                .orElseGet(() ->  Response.status(Status.NOT_FOUND)).build();
     }
 
 
     @Override
     public Response getUsers(){
-        return userService.findAllUsers().stream().map(UserRestDto::new).toList().isEmpty()
-                ? Response.status(Status.NO_CONTENT).build()
-                : Response.ok().entity(userService.findAllUsers().stream().map(UserRestDto::new).toList()).build();
+        return Response.ok(userService.findAllUsers()
+                .stream()
+                .map(UserRestDto::new)
+                .toList())
+                .build();
 
     }
 
     @Override
     public Response getUsersIncludeDeleted() {
-        return userService.findAllUsersIncludeDeleted().stream().map(UserRestDto::new).toList().isEmpty()
-                ? Response.status(Status.NO_CONTENT).build()
-                : Response.ok().entity(userService.findAllUsersIncludeDeleted().stream().map(UserRestDto::new).toList()).build();
+        return Response.ok(userService.findAllUsersIncludeDeleted()
+                        .stream()
+                        .map(UserRestDto::new)
+                        .toList())
+                .build();
     }
 
     @Override

--- a/gamertrack-application/src/test/java/com/gepardec/rest/impl/MatchControllerRequest.http
+++ b/gamertrack-application/src/test/java/com/gepardec/rest/impl/MatchControllerRequest.http
@@ -1,25 +1,25 @@
-GET http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/matches
+GET http://localhost:8080/gepardec-gamertrack/api/v1/matches
 
 ### (1) CREATE MATCH - Create game first
 ### (1) CREATE USER AND GAME BEFORE BECAUSE OF RELATIONSHIPS
 
-POST http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/games
+POST http://localhost:8080/gepardec-gamertrack/api/v1/games
 Content-Type: application/json
 Accept: application/json
 
 {
-  "title": "Games",
+  "title": "Gams4",
   "rules": "Gamrules"
 }
 
 
 ###
-GET http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/games
+GET http://localhost:8080/gepardec-gamertrack/api/v1/games
 
 
 ### (2) Create users
 
-POST http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/users
+POST http://localhost:8080/gepardec-gamertrack/api/v1/users
 Content-Type:application/json
 
 {
@@ -28,7 +28,7 @@ Content-Type:application/json
 }
 
 ###
-POST http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/users
+POST http://localhost:8080/gepardec-gamertrack/api/v1/users
 Content-Type:application/json
 
 {
@@ -37,17 +37,17 @@ Content-Type:application/json
 }
 
 ####
-GET http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/users
+GET http://localhost:8080/gepardec-gamertrack/api/v1/users
 
 
 
 ###
-POST http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/matches
+POST http://localhost:8080/gepardec-gamertrack/api/v1/matches
 Content-Type: application/json
 Accept: application/json
 
 {
-  "gameId": 1,
+  "gameId": 2,
   "userIds": [
     1,
     2
@@ -56,27 +56,36 @@ Accept: application/json
 
 
 ###
-GET http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/matches
+GET http://localhost:8080/gepardec-gamertrack/api/v1/matches
 
 ####
 
-GET http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/matches?userId=1
+GET http://localhost:8080/gepardec-gamertrack/api/v1/matches?userId=1
 
 
 
 ###
 
-PUT http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/matches/2
+PUT http://localhost:8080/gepardec-gamertrack/api/v1/matches/1
 Content-Type: application/json
 Accept: application/json
 
 {
   "gameId": 1,
   "userIds": [
-    2
+    1
   ]
 }
 
 ####
 
-DELETE http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/matches/1
+##DELETE http://localhost:8080/gepardec-gamertrack/api/v1/matches/1
+
+
+#### QUERIES
+
+
+### FIND MATCHES BY USER_ID AND GAME_ID
+
+GET http://localhost:8080/gepardec-gamertrack/api/v1/matches?userId=2&gameId=2
+

--- a/gamertrack-application/src/test/java/com/gepardec/rest/impl/UserRestControllerRequest.http
+++ b/gamertrack-application/src/test/java/com/gepardec/rest/impl/UserRestControllerRequest.http
@@ -21,7 +21,8 @@ Content-Type:application/json
 %}
 
 ###
-DELETE http://localhost:8080/gamertrack-war-1.0-SNAPSHOT/api/v1/users/5
+
+DELETE http://localhost:8080/gepardec-gamertrack/api/v1/users/1
 Content-Type:application/json
 
 > {%

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/MatchRepositoryImpl.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/MatchRepositoryImpl.java
@@ -48,7 +48,7 @@ public class MatchRepositoryImpl implements MatchRepository {
 
   @Override
   public void deleteMatch(Long matchId) {
-    logger.info("Looking up game outcome by id: %s in order to delet".formatted(matchId));
+    logger.info("Looking up matches by id: %s in order to delet".formatted(matchId));
     Optional<Match> matchToDelete = findMatchById(matchId);
 
     if (matchToDelete.isEmpty()) {
@@ -89,6 +89,17 @@ public class MatchRepositoryImpl implements MatchRepository {
     var query = em.createQuery("select go from Match go where go.game.id = :gameId ",
         Match.class);
 
+    query.setParameter("gameId", gameId);
+    return query.getResultList();
+  }
+
+  @Override
+  public List<Match> findMatchByUserIdAndGameId(Long userId, Long gameId) {
+    logger.info("Finding matches by UserId: {} and GameId: {}".formatted(userId, gameId));
+    var query = em.createQuery(
+        "select m from Match m inner join m.users u where (:userId is NULL OR u.id = :userId) and (:gameId is NULL OR m.game.id = :gameId)",
+        Match.class);
+    query.setParameter("userId", userId);
     query.setParameter("gameId", gameId);
     return query.getResultList();
   }

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/MatchRepositoryImpl.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/MatchRepositoryImpl.java
@@ -73,7 +73,7 @@ public class MatchRepositoryImpl implements MatchRepository {
   }
 
   @Override
-  public List<Match> findMatchByUserId(Long userId) {
+  public List<Match> findMatchesByUserId(Long userId) {
     logger.info("Finding all matches by userId: %s".formatted(userId));
     var query = em.createQuery(
         "select go from Match go inner join go.users u where u.id = :userId ",
@@ -84,7 +84,7 @@ public class MatchRepositoryImpl implements MatchRepository {
   }
 
   @Override
-  public List<Match> findMatchByGameId(Long gameId) {
+  public List<Match> findMatchesByGameId(Long gameId) {
     logger.info("Finding all games outcomes by gameId: %s".formatted(gameId));
     var query = em.createQuery("select go from Match go where go.game.id = :gameId ",
         Match.class);
@@ -94,7 +94,7 @@ public class MatchRepositoryImpl implements MatchRepository {
   }
 
   @Override
-  public List<Match> findMatchByUserIdAndGameId(Long userId, Long gameId) {
+  public List<Match> findMatchesByUserIdAndGameId(Long userId, Long gameId) {
     logger.info("Finding matches by UserId: {} and GameId: {}".formatted(userId, gameId));
     var query = em.createQuery(
         "select m from Match m inner join m.users u where (:userId is NULL OR u.id = :userId) and (:gameId is NULL OR m.game.id = :gameId)",

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/ScoreRepositoryImpl.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/ScoreRepositoryImpl.java
@@ -84,6 +84,25 @@ public class ScoreRepositoryImpl implements ScoreRepository, Serializable {
     }
 
     @Override
+    public List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId) {
+        List<Score> resultList = entityManager.createQuery(
+                "SELECT s FROM Score s " +
+                        "WHERE (:minPoints is null OR :minPoints <= s.scorePoints) " +
+                        "AND (:maxPoints is null OR s.scorePoints <= :maxPoints) " +
+                        "AND s.user.deactivated = false " +
+                        "AND (:userId is null OR s.user.id = :userId) " +
+                        "AND (:gameId is null OR s.game.id = :gameId) " +
+                        "order by s.scorePoints", Score.class)
+                .setParameter("minPoints", minPoints)
+                .setParameter("maxPoints", maxPoints)
+                .setParameter("userId", userId)
+                .setParameter("gameId", gameId)
+                .getResultList();
+        log.info("Filter score by minPoints: {}, maxPoints: {}, userId: {}, gameId: {}. Resultsize: {}", minPoints,maxPoints, userId, gameId, resultList.size());
+
+        return resultList;    }
+
+    @Override
     public List<Score> findScoreByUser(Long userId) {
         List<Score> resultList = entityManager.createQuery("SELECT s FROM Score s WHERE s.user.id = :userId " +
                         "AND s.user.deactivated = false", Score.class)

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/ScoreRepositoryImpl.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/ScoreRepositoryImpl.java
@@ -102,27 +102,6 @@ public class ScoreRepositoryImpl implements ScoreRepository, Serializable {
 
         return resultList;    }
 
-    @Override
-    public List<Score> findScoreByUser(Long userId) {
-        List<Score> resultList = entityManager.createQuery("SELECT s FROM Score s WHERE s.user.id = :userId " +
-                        "AND s.user.deactivated = false", Score.class)
-                .setParameter("userId", userId)
-                .getResultList();
-        log.info("Find score with userId: {}. Returned list of size:{}", userId, resultList.size());
-
-        return resultList;
-    }
-
-    @Override
-    public List<Score> findScoreByGame(Long gameId) {
-        List<Score> resultList = entityManager.createQuery("SELECT s FROM Score s WHERE s.game.id = :gameId " +
-                        "AND s.user.deactivated = false", Score.class)
-                .setParameter("gameId", gameId)
-                .getResultList();
-        log.info("Find score with gameId: {}. Returned list of size:{}", gameId, resultList.size());
-
-        return resultList;
-    }
 
     @Override
     public List<Score> findTopScoreByGame(Long gameId, int top) {
@@ -144,18 +123,6 @@ public class ScoreRepositoryImpl implements ScoreRepository, Serializable {
                 .setParameter("scorePoints", scorePoints)
                 .getResultList();
         log.info("Find score with {} ScorePoints. Returned list of size:{}", scorePoints, resultList.size());
-
-        return resultList;
-    }
-
-    @Override
-    public List<Score> findScoreByMinMaxScorePoints(double minPoints, double maxPoints) {
-        List<Score> resultList = entityManager.createQuery("SELECT s FROM Score s WHERE :minPoints <= s.scorePoints " +
-                        "AND s.scorePoints <= :maxPoints AND s.user.deactivated = false order by s.scorePoints", Score.class)
-                .setParameter("minPoints", minPoints)
-                .setParameter("maxPoints", maxPoints)
-                .getResultList();
-        log.info("Find score with scorePoints between {} and {}. Returned list of size:{}", minPoints,maxPoints, resultList);
 
         return resultList;
     }

--- a/gamertrack-domain/src/main/java/com/gepardec/core/repository/MatchRepository.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/repository/MatchRepository.java
@@ -17,13 +17,13 @@ public interface MatchRepository {
 
   Optional<Match> updateMatch(MatchDto gameOutcomeDto);
 
-  List<Match> findMatchByUserId(Long userId);
+  List<Match> findMatchesByUserId(Long userId);
 
-  List<Match> findMatchByGameId(Long gameId);
+  List<Match> findMatchesByGameId(Long gameId);
 
   Boolean existsMatchById(Long gameOutcomeId);
 
-  List<Match> findMatchByUserIdAndGameId(Long userId, Long gameId);
+  List<Match> findMatchesByUserIdAndGameId(Long userId, Long gameId);
 
 
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/core/repository/MatchRepository.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/repository/MatchRepository.java
@@ -23,5 +23,7 @@ public interface MatchRepository {
 
   Boolean existsMatchById(Long gameOutcomeId);
 
+  List<Match> findMatchByUserIdAndGameId(Long userId, Long gameId);
+
 
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/core/repository/ScoreRepository.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/repository/ScoreRepository.java
@@ -7,11 +7,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ScoreRepository {
-    List<Score> findAllScores();
     Optional<Score> findScoreById(Long id);
-    List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId);
-    List<Score> findTopScoreByGame(Long gameId, int top);
-    List<Score> findScoreByScorePoints(double scorePoints);
+    List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId,Boolean includeDeactivatedUsers);
+    List<Score> findTopScoreByGame(Long gameId, int top, Boolean includeDeactivatedUsers);
+    List<Score> findScoreByScorePoints(double scorePoints, Boolean includeDeactivatedUsers);
     Optional<Score> saveScore(ScoreDto scoreDto);
     Optional<Score> updateScore(ScoreDto scoreDto);
     boolean scoreExists(ScoreDto scoreDto);

--- a/gamertrack-domain/src/main/java/com/gepardec/core/repository/ScoreRepository.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/repository/ScoreRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface ScoreRepository {
     List<Score> findAllScores();
     Optional<Score> findScoreById(Long id);
+    List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId);
     List<Score> findScoreByUser(Long userId);
     List<Score> findScoreByGame(Long gameId);
     List<Score> findTopScoreByGame(Long gameId, int top);

--- a/gamertrack-domain/src/main/java/com/gepardec/core/repository/ScoreRepository.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/repository/ScoreRepository.java
@@ -10,11 +10,8 @@ public interface ScoreRepository {
     List<Score> findAllScores();
     Optional<Score> findScoreById(Long id);
     List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId);
-    List<Score> findScoreByUser(Long userId);
-    List<Score> findScoreByGame(Long gameId);
     List<Score> findTopScoreByGame(Long gameId, int top);
     List<Score> findScoreByScorePoints(double scorePoints);
-    List<Score> findScoreByMinMaxScorePoints(double minPoints, double maxPoints);
     Optional<Score> saveScore(ScoreDto scoreDto);
     Optional<Score> updateScore(ScoreDto scoreDto);
     boolean scoreExists(ScoreDto scoreDto);

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/MatchService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/MatchService.java
@@ -17,9 +17,9 @@ public interface MatchService {
 
   Optional<Match> updateMatch(MatchDto gameOutcomeDto);
 
-  List<Match> findMatchByUserId(Long userId);
+  List<Match> findMatchesByUserId(Long userId);
 
-  List<Match> findMatchsByGameId(Long gameId);
+  List<Match> findMatchesByGameId(Long gameId);
 
   List<Match> findMatchesByUserIdAndGameId(Optional<Long> userId, Optional<Long> gameId);
 

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/MatchService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/MatchService.java
@@ -21,4 +21,6 @@ public interface MatchService {
 
   List<Match> findMatchsByGameId(Long gameId);
 
+  List<Match> findMatchesByUserIdAndGameId(Optional<Long> userId, Optional<Long> gameId);
+
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
@@ -10,11 +10,11 @@ public interface ScoreService {
     List<Score> findAllScores();
     Optional<Score> findScoreById(Long id);
     List<Score> findScoresFilter(Optional<Double> minPoints, Optional<Double> maxPoints,Optional<Long> userId,Optional<Long> gameId);
-    List<Score> findScoreByUser(Long userId);
-    List<Score> findScoreByGame(Long gameId);
-    List<Score> findTopScoreByGame(Long gameId, int top);
-    List<Score> findScoreByScorePoints(double scorePoints);
-    List<Score> findScoreByMinMaxScorePoints(double minPoints, double maxPoints);
+    List<Score> findScoresByUser(Long userId);
+    List<Score> findScoresByGame(Long gameId);
+    List<Score> findTopScoresByGame(Long gameId, int top);
+    List<Score> findScoreByScoresPoints(double scorePoints);
+    List<Score> findScoreByMinMaxScoresPoints(double minPoints, double maxPoints);
     Optional<Score> saveScore(ScoreDto scoreDto);
     Optional<Score> updateScore(ScoreDto scoreDto);
     boolean scoreExists(ScoreDto scoreDto);

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
@@ -7,14 +7,14 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ScoreService {
-    List<Score> findAllScores();
+    List<Score> findAllScores(Boolean includeDeactivated);
     Optional<Score> findScoreById(Long id);
-    List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId);
-    List<Score> findScoresByUser(Long userId);
-    List<Score> findScoresByGame(Long gameId);
-    List<Score> findTopScoresByGame(Long gameId, int top);
-    List<Score> findScoreByScoresPoints(double scorePoints);
-    List<Score> findScoreByMinMaxScoresPoints(double minPoints, double maxPoints);
+    List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId, Boolean includeDeactivatedUsers);
+    List<Score> findScoresByUser(Long userId, Boolean includeDeactivatedUsers);
+    List<Score> findScoresByGame(Long gameId, Boolean includeDeactivatedUsers);
+    List<Score> findTopScoresByGame(Long gameId, int top, Boolean includeDeactivatedUsers);
+    List<Score> findScoreByScoresPoints(double scorePoints, Boolean includeDeactivatedUsers);
+    List<Score> findScoreByMinMaxScoresPoints(double minPoints, double maxPoints, Boolean includeDeactivatedUsers);
     Optional<Score> saveScore(ScoreDto scoreDto);
     Optional<Score> updateScore(ScoreDto scoreDto);
     boolean scoreExists(ScoreDto scoreDto);

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
@@ -10,6 +10,7 @@ public interface ScoreService {
     List<Score> findAllScores();
     Optional<Score> findScoreById(Long id);
     List<Score> findScoresFilter(Optional<Double> minPoints, Optional<Double> maxPoints,Optional<Long> userId,Optional<Long> gameId);
+    List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId);
     List<Score> findScoresByUser(Long userId);
     List<Score> findScoresByGame(Long gameId);
     List<Score> findTopScoresByGame(Long gameId, int top);

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface ScoreService {
     List<Score> findAllScores();
     Optional<Score> findScoreById(Long id);
+    List<Score> findScoresFilter(Optional<Double> minPoints, Optional<Double> maxPoints,Optional<Long> userId,Optional<Long> gameId);
     List<Score> findScoreByUser(Long userId);
     List<Score> findScoreByGame(Long gameId);
     List<Score> findTopScoreByGame(Long gameId, int top);

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/ScoreService.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 public interface ScoreService {
     List<Score> findAllScores();
     Optional<Score> findScoreById(Long id);
-    List<Score> findScoresFilter(Optional<Double> minPoints, Optional<Double> maxPoints,Optional<Long> userId,Optional<Long> gameId);
     List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId);
     List<Score> findScoresByUser(Long userId);
     List<Score> findScoresByGame(Long gameId);

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/MatchServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/MatchServiceImpl.java
@@ -9,6 +9,7 @@ import com.gepardec.model.dto.MatchDto;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -29,6 +30,23 @@ public class MatchServiceImpl implements MatchService {
   @Inject
   private GameRepository gameRepository;
 
+
+  @Override
+  public List<Match> findMatchesByUserIdAndGameId(Optional<Long> userId, Optional<Long> gameId) {
+
+    if (userId.isPresent() && gameId.isPresent()) {
+      logger.info("Finding matches by userId {} and gameId {}".formatted(userId, gameId));
+      return matchRepository.findMatchByUserIdAndGameId(userId.get(), gameId.get());
+    }
+
+    return userId
+        .map(uid -> matchRepository.findMatchByUserId(
+            uid))
+        .orElseGet(() -> gameId
+            .map(gid -> matchRepository.findMatchByGameId(
+                gid))
+            .orElse(Collections.emptyList()));
+  }
 
   @Override
   public Optional<Match> saveMatch(MatchDto matchDto) {

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/MatchServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/MatchServiceImpl.java
@@ -36,14 +36,14 @@ public class MatchServiceImpl implements MatchService {
 
     if (userId.isPresent() && gameId.isPresent()) {
       logger.info("Finding matches by userId {} and gameId {}".formatted(userId, gameId));
-      return matchRepository.findMatchByUserIdAndGameId(userId.get(), gameId.get());
+      return matchRepository.findMatchesByUserIdAndGameId(userId.get(), gameId.get());
     }
 
     return userId
-        .map(uid -> matchRepository.findMatchByUserId(
+        .map(uid -> matchRepository.findMatchesByUserId(
             uid))
         .orElseGet(() -> gameId
-            .map(gid -> matchRepository.findMatchByGameId(
+            .map(gid -> matchRepository.findMatchesByGameId(
                 gid))
             .orElse(Collections.emptyList()));
   }
@@ -116,16 +116,16 @@ public class MatchServiceImpl implements MatchService {
   }
 
   @Override
-  public List<Match> findMatchByUserId(Long userId) {
+  public List<Match> findMatchesByUserId(Long userId) {
     logger.info(
         "Getting all existing matches that reference user with UserID: %s".formatted(userId));
-    return matchRepository.findMatchByUserId(userId);
+    return matchRepository.findMatchesByUserId(userId);
   }
 
   @Override
-  public List<Match> findMatchsByGameId(Long gameId) {
+  public List<Match> findMatchesByGameId(Long gameId) {
     logger.info(
         "Getting all existing matches that reference game with GameID: %s".formatted(gameId));
-    return matchRepository.findMatchByGameId(gameId);
+    return matchRepository.findMatchesByGameId(gameId);
   }
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
@@ -56,26 +56,6 @@ public class ScoreServiceImpl implements ScoreService, Serializable {
     }
 
     @Override
-    public List<Score> findScoresFilter(Optional<Double> minPoints, Optional<Double> maxPoints, Optional<Long> userId, Optional<Long> gameId) {
-        double min = minPoints.orElse(0.0);
-        double max = maxPoints.orElse(Double.MAX_VALUE); // only tmp -> paging
-
-        if(min > max) {
-            double tmp = max;
-            max = min;
-            min = tmp;
-            log.info("switched minPoints with maxPoint because minPoints was greater than maxPoints");
-        }
-
-        List<Score> allScores = scoreRepository.findScoreByMinMaxScorePoints(min, max);
-        return allScores.stream().filter(
-                score ->
-                        (gameId.isEmpty() || (score.getGame() != null && score.getGame().getId().equals(gameId.get()))) &&
-                        (userId.isEmpty() || (score.getUser() != null && score.getUser().getId().equals(userId.get())))
-                        ).collect(Collectors.toList());
-    }
-
-    @Override
     public List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId) {
 
         if(minPoints != null && maxPoints != null) {

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
@@ -74,12 +74,12 @@ public class ScoreServiceImpl implements ScoreService, Serializable {
 
     @Override
     public List<Score> findScoresByUser(Long userId) {
-        return scoreRepository.findScoreByUser(userId);
+        return scoreRepository.filterScores(null,null,userId,null);
     }
 
     @Override
     public List<Score> findScoresByGame(Long gameId) {
-        return scoreRepository.findScoreByGame(gameId);
+        return scoreRepository.filterScores(null,null,null,gameId);
     }
 
     @Override
@@ -100,7 +100,7 @@ public class ScoreServiceImpl implements ScoreService, Serializable {
             minPoints = tmp;
             log.info("switched minPoints with maxPoint because minPoints was greater than maxPoints");
         }
-        return scoreRepository.findScoreByMinMaxScorePoints(minPoints, maxPoints);
+        return scoreRepository.filterScores(minPoints,maxPoints,null,null);
     }
 
     @Override

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
@@ -76,27 +76,27 @@ public class ScoreServiceImpl implements ScoreService, Serializable {
     }
 
     @Override
-    public List<Score> findScoreByUser(Long userId) {
+    public List<Score> findScoresByUser(Long userId) {
         return scoreRepository.findScoreByUser(userId);
     }
 
     @Override
-    public List<Score> findScoreByGame(Long gameId) {
+    public List<Score> findScoresByGame(Long gameId) {
         return scoreRepository.findScoreByGame(gameId);
     }
 
     @Override
-    public List<Score> findTopScoreByGame(Long gameId, int top) {
+    public List<Score> findTopScoresByGame(Long gameId, int top) {
         return scoreRepository.findTopScoreByGame(gameId,top);
     }
 
     @Override
-    public List<Score> findScoreByScorePoints(double scorePoints) {
+    public List<Score> findScoreByScoresPoints(double scorePoints) {
         return scoreRepository.findScoreByScorePoints(scorePoints);
     }
 
     @Override
-    public List<Score> findScoreByMinMaxScorePoints(double minPoints, double maxPoints) {
+    public List<Score> findScoreByMinMaxScoresPoints(double minPoints, double maxPoints) {
         if(minPoints > maxPoints) {
             double tmp = maxPoints;
             maxPoints = minPoints;

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
@@ -46,8 +46,8 @@ public class ScoreServiceImpl implements ScoreService, Serializable {
     }
 
     @Override
-    public List<Score> findAllScores() {
-        return scoreRepository.findAllScores();
+    public List<Score> findAllScores(Boolean includeDeactivatedUsers) {
+        return scoreRepository.filterScores(null,null,null,null, includeDeactivatedUsers);
     }
 
     @Override
@@ -56,7 +56,7 @@ public class ScoreServiceImpl implements ScoreService, Serializable {
     }
 
     @Override
-    public List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId) {
+    public List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId, Boolean includeDeactivatedUsers) {
 
         if(minPoints != null && maxPoints != null) {
             if (minPoints > maxPoints) {
@@ -67,40 +67,40 @@ public class ScoreServiceImpl implements ScoreService, Serializable {
             }
         }
 
-       return scoreRepository.filterScores(minPoints, maxPoints, userId, gameId);
+       return scoreRepository.filterScores(minPoints, maxPoints, userId, gameId,includeDeactivatedUsers);
     }
 
 
 
     @Override
-    public List<Score> findScoresByUser(Long userId) {
-        return scoreRepository.filterScores(null,null,userId,null);
+    public List<Score> findScoresByUser(Long userId, Boolean includeDeactivatedUsers) {
+        return scoreRepository.filterScores(null,null,userId,null, includeDeactivatedUsers);
     }
 
     @Override
-    public List<Score> findScoresByGame(Long gameId) {
-        return scoreRepository.filterScores(null,null,null,gameId);
+    public List<Score> findScoresByGame(Long gameId, Boolean includeDeactivatedUsers) {
+        return scoreRepository.filterScores(null,null,null,gameId, includeDeactivatedUsers);
     }
 
     @Override
-    public List<Score> findTopScoresByGame(Long gameId, int top) {
-        return scoreRepository.findTopScoreByGame(gameId,top);
+    public List<Score> findTopScoresByGame(Long gameId, int top, Boolean includeDeactivatedUsers) {
+        return scoreRepository.findTopScoreByGame(gameId,top,includeDeactivatedUsers);
     }
 
     @Override
-    public List<Score> findScoreByScoresPoints(double scorePoints) {
-        return scoreRepository.findScoreByScorePoints(scorePoints);
+    public List<Score> findScoreByScoresPoints(double scorePoints, Boolean includeDeactivatedUsers) {
+        return scoreRepository.findScoreByScorePoints(scorePoints, includeDeactivatedUsers);
     }
 
     @Override
-    public List<Score> findScoreByMinMaxScoresPoints(double minPoints, double maxPoints) {
+    public List<Score> findScoreByMinMaxScoresPoints(double minPoints, double maxPoints, Boolean includeDeactivatedUsers) {
         if(minPoints > maxPoints) {
             double tmp = maxPoints;
             maxPoints = minPoints;
             minPoints = tmp;
             log.info("switched minPoints with maxPoint because minPoints was greater than maxPoints");
         }
-        return scoreRepository.filterScores(minPoints,maxPoints,null,null);
+        return scoreRepository.filterScores(minPoints,maxPoints,null,null,includeDeactivatedUsers);
     }
 
     @Override

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Transactional
 @Stateless
@@ -52,6 +53,26 @@ public class ScoreServiceImpl implements ScoreService, Serializable {
     @Override
     public Optional<Score> findScoreById(Long id) {
         return scoreRepository.findScoreById(id);
+    }
+
+    @Override
+    public List<Score> findScoresFilter(Optional<Double> minPoints, Optional<Double> maxPoints, Optional<Long> userId, Optional<Long> gameId) {
+        double min = minPoints.orElse(0.0);
+        double max = maxPoints.orElse(Double.MAX_VALUE); // only tmp -> paging
+
+        if(min > max) {
+            double tmp = max;
+            max = min;
+            min = tmp;
+            log.info("switched minPoints with maxPoint because minPoints was greater than maxPoints");
+        }
+
+        List<Score> allScores = scoreRepository.findScoreByMinMaxScorePoints(min, max);
+        return allScores.stream().filter(
+                score ->
+                        (gameId.isEmpty() || (score.getGame() != null && score.getGame().getId().equals(gameId.get()))) &&
+                        (userId.isEmpty() || (score.getUser() != null && score.getUser().getId().equals(userId.get())))
+                        ).collect(Collectors.toList());
     }
 
     @Override

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/ScoreServiceImpl.java
@@ -76,6 +76,23 @@ public class ScoreServiceImpl implements ScoreService, Serializable {
     }
 
     @Override
+    public List<Score> filterScores(Double minPoints, Double maxPoints, Long userId, Long gameId) {
+
+        if(minPoints != null && maxPoints != null) {
+            if (minPoints > maxPoints) {
+                double tmp = maxPoints;
+                maxPoints = minPoints;
+                minPoints = tmp;
+                log.info("switched minPoints with maxPoint because minPoints was greater than maxPoints");
+            }
+        }
+
+       return scoreRepository.filterScores(minPoints, maxPoints, userId, gameId);
+    }
+
+
+
+    @Override
     public List<Score> findScoresByUser(Long userId) {
         return scoreRepository.findScoreByUser(userId);
     }

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/UserServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/UserServiceImpl.java
@@ -54,7 +54,7 @@ public class UserServiceImpl implements UserService, Serializable {
 
             if(user.isPresent()){
                 log.info("deleting: user with the id {} is present", id);
-                List<Score> scoresByUser = scoreService.findScoreByUser(user.get().getId());
+                List<Score> scoresByUser = scoreService.findScoresByUser(user.get().getId());
                 if(scoresByUser.isEmpty()){
                     log.info("user with the id {} has no scores stored. deleting user", id);
 

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/UserServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/UserServiceImpl.java
@@ -54,7 +54,7 @@ public class UserServiceImpl implements UserService, Serializable {
 
             if(user.isPresent()){
                 log.info("deleting: user with the id {} is present", id);
-                List<Score> scoresByUser = scoreService.findScoresByUser(user.get().getId());
+                List<Score> scoresByUser = scoreService.findScoresByUser(user.get().getId(),true);
                 if(scoresByUser.isEmpty()){
                     log.info("user with the id {} has no scores stored. deleting user", id);
 

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/MatchServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/MatchServiceImplTest.java
@@ -158,10 +158,10 @@ class MatchServiceImplTest {
   void ensureFindMatchByUserIdReturnsListOfMatchesForExistingMatchWithUserId() {
     Match match = TestFixtures.match();
 
-    when(matchRepository.findMatchByUserId(anyLong())).thenReturn(
+    when(matchRepository.findMatchesByUserId(anyLong())).thenReturn(
         List.of(match));
 
-    var foundMatches = matchService.findMatchByUserId(
+    var foundMatches = matchService.findMatchesByUserId(
         match.getUsers().getFirst().getId());
 
     assertTrue(foundMatches.contains(match));
@@ -170,9 +170,9 @@ class MatchServiceImplTest {
   @Test
   void ensureFindMatchByUserIdReturnsEmptyListForNonExistingMatch() {
     Match match = TestFixtures.match();
-    when(matchRepository.findMatchByUserId(anyLong())).thenReturn(List.of());
+    when(matchRepository.findMatchesByUserId(anyLong())).thenReturn(List.of());
 
-    var foundMatches = matchService.findMatchByUserId(
+    var foundMatches = matchService.findMatchesByUserId(
         match.getUsers().getFirst().getId());
 
     assertTrue(foundMatches.isEmpty());
@@ -183,9 +183,9 @@ class MatchServiceImplTest {
   void ensureFindMatchByGameIdReturnsListOfMatchesForExistingMatch() {
     Match match = TestFixtures.match();
 
-    when(matchRepository.findMatchByGameId(anyLong())).thenReturn(List.of(match));
+    when(matchRepository.findMatchesByGameId(anyLong())).thenReturn(List.of(match));
 
-    var matches = matchService.findMatchsByGameId(match.getGame().getId());
+    var matches = matchService.findMatchesByGameId(match.getGame().getId());
 
     assertTrue(matches.contains(match));
   }
@@ -194,9 +194,9 @@ class MatchServiceImplTest {
   void ensureFindMatchByGameIdReturnsEmptyListForNonExistingMatch() {
     Match match = TestFixtures.match();
 
-    when(matchRepository.findMatchByGameId(anyLong())).thenReturn(List.of());
+    when(matchRepository.findMatchesByGameId(anyLong())).thenReturn(List.of());
 
-    var foundGameOutcomes = matchService.findMatchsByGameId(
+    var foundGameOutcomes = matchService.findMatchesByGameId(
         match.getGame().getId());
 
     assertTrue(foundGameOutcomes.isEmpty());
@@ -206,7 +206,7 @@ class MatchServiceImplTest {
   @Test
   void ensureFindMatchByUserIdAndGameIdReturnsListOfMatchesForExistingMatch() {
     List<Match> matches = TestFixtures.matches(5);
-    when(matchRepository.findMatchByUserIdAndGameId(anyLong(), anyLong())).thenReturn(matches);
+    when(matchRepository.findMatchesByUserIdAndGameId(anyLong(), anyLong())).thenReturn(matches);
 
     var foundMatches = matchService.findMatchesByUserIdAndGameId(Optional.of(1L), Optional.of(2L));
     assertTrue(matches.contains(matches.get(0)));
@@ -216,7 +216,7 @@ class MatchServiceImplTest {
   @Test
   void ensureFindMatchByUserIdAndGameIdReturnsEmptyListForNonExistingMatch() {
     List<Match> matches = TestFixtures.matches(5);
-    when(matchRepository.findMatchByUserIdAndGameId(anyLong(), anyLong())).thenReturn(List.of());
+    when(matchRepository.findMatchesByUserIdAndGameId(anyLong(), anyLong())).thenReturn(List.of());
     var foundMatches = matchService.findMatchesByUserIdAndGameId(Optional.of(1L), Optional.of(2L));
 
     assertTrue(foundMatches.isEmpty());
@@ -227,7 +227,7 @@ class MatchServiceImplTest {
     Match match = TestFixtures.match();
     List<Match> matches = new ArrayList<>();
     matches.add(match);
-    when(matchRepository.findMatchByGameId(anyLong())).thenReturn(matches);
+    when(matchRepository.findMatchesByGameId(anyLong())).thenReturn(matches);
 
     var foundMatches = matchService.findMatchesByUserIdAndGameId(Optional.empty(),
         Optional.of(match.getId()));
@@ -244,7 +244,7 @@ class MatchServiceImplTest {
     List<Match> matches = new ArrayList<>();
     matches.add(match);
 
-    when(matchRepository.findMatchByUserId(anyLong())).thenReturn(matches);
+    when(matchRepository.findMatchesByUserId(anyLong())).thenReturn(matches);
 
     var foundmatches = matchService.findMatchesByUserIdAndGameId(
         Optional.of(match.getUsers().getFirst().getId()),

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/MatchServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/MatchServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.gepardec.impl.service;
 
+import static com.gepardec.TestFixtures.matches;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -80,7 +81,7 @@ class MatchServiceImplTest {
 
   @Test
   void ensureFindAllMatchesReturnsAllMatches() {
-    List<Match> matches = TestFixtures.matches(10);
+    List<Match> matches = matches(10);
 
     when(matchRepository.findAllMatches()).thenReturn(matches);
 
@@ -200,5 +201,66 @@ class MatchServiceImplTest {
 
     assertTrue(foundGameOutcomes.isEmpty());
 
+  }
+
+  @Test
+  void ensureFindMatchByUserIdAndGameIdReturnsListOfMatchesForExistingMatch() {
+    List<Match> matches = TestFixtures.matches(5);
+    when(matchRepository.findMatchByUserIdAndGameId(anyLong(), anyLong())).thenReturn(matches);
+
+    var foundMatches = matchService.findMatchesByUserIdAndGameId(Optional.of(1L), Optional.of(2L));
+    assertTrue(matches.contains(matches.get(0)));
+    assertEquals(matches.size(), foundMatches.size());
+  }
+
+  @Test
+  void ensureFindMatchByUserIdAndGameIdReturnsEmptyListForNonExistingMatch() {
+    List<Match> matches = TestFixtures.matches(5);
+    when(matchRepository.findMatchByUserIdAndGameId(anyLong(), anyLong())).thenReturn(List.of());
+    var foundMatches = matchService.findMatchesByUserIdAndGameId(Optional.of(1L), Optional.of(2L));
+
+    assertTrue(foundMatches.isEmpty());
+  }
+
+  @Test
+  void ensureFindMatchByUserIdAndGameIdReturnsExistingMatchForUserIdNotBeingSpecified() {
+    Match match = TestFixtures.match();
+    List<Match> matches = new ArrayList<>();
+    matches.add(match);
+    when(matchRepository.findMatchByGameId(anyLong())).thenReturn(matches);
+
+    var foundMatches = matchService.findMatchesByUserIdAndGameId(Optional.empty(),
+        Optional.of(match.getId()));
+
+    assertTrue(foundMatches.contains(match));
+    assertEquals(foundMatches.size(), matches.size());
+    assertEquals(match, foundMatches.stream().findFirst().get());
+
+  }
+
+  @Test
+  void ensureFindMatchByUserIdAndGameIdReturnsExistingMatchForGameIdNotBeingSpecified() {
+    Match match = TestFixtures.match();
+    List<Match> matches = new ArrayList<>();
+    matches.add(match);
+
+    when(matchRepository.findMatchByUserId(anyLong())).thenReturn(matches);
+
+    var foundmatches = matchService.findMatchesByUserIdAndGameId(
+        Optional.of(match.getUsers().getFirst().getId()),
+        Optional.empty());
+
+    assertTrue(foundmatches.contains(match));
+    assertEquals(foundmatches.size(), matches.size());
+    assertEquals(match, foundmatches.stream().findFirst().get());
+  }
+
+  @Test
+  void ensureFindMatchByUserIdAndGameReturnsEmptyListForBothEmptyParameters() {
+
+    var foundMatches = matchService.findMatchesByUserIdAndGameId(Optional.empty(),
+        Optional.empty());
+
+    assertTrue(foundMatches.isEmpty());
   }
 }

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
@@ -143,7 +143,7 @@ public class ScoreServiceImplTest {
     void ensureFindScoresByUserWorksAndReturnsScores() {
         List<Score> scores = TestFixtures.scores(3);
 
-        when(scoreRepository.findScoreByUser(2L)).thenReturn(List.of(scores.get(1)));
+        when(scoreRepository.filterScores(null,null,2L,null)).thenReturn(List.of(scores.get(1)));
 
         List<Score> foundScore = scoreService.findScoresByUser(2L);
 
@@ -157,7 +157,7 @@ public class ScoreServiceImplTest {
     void ensureFindScoresByGameWorksAndReturnsScores() {
         List<Score> scores = TestFixtures.scores(3);
 
-        when(scoreRepository.findScoreByGame(1L)).thenReturn(List.of(scores.getFirst()));
+        when(scoreRepository.filterScores(null,null,null,1L)).thenReturn(List.of(scores.getFirst()));
 
         List<Score> foundScore = scoreService.findScoresByGame(1L);
 
@@ -183,7 +183,7 @@ public class ScoreServiceImplTest {
     void ensureFindScoresByMinMaxPointsWorksAndReturnsScore() {
         List<Score> scores = TestFixtures.scores(3);
 
-        when(scoreRepository.findScoreByMinMaxScorePoints(11,30)).thenReturn(scores);
+        when(scoreRepository.filterScores(11D,30D,null,null)).thenReturn(scores);
 
         List<Score> foundScore = scoreService.findScoreByMinMaxScoresPoints(11,30);
 

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
@@ -87,9 +87,9 @@ public class ScoreServiceImplTest {
     void ensureFindAllScoresWorksAndReturnsAllScores() {
         List<Score> scores = TestFixtures.scores(3);
 
-        when(scoreRepository.findAllScores()).thenReturn(scores);
+        when(scoreRepository.filterScores(null,null,null,null,true)).thenReturn(scores);
 
-        List<Score> foundScore = scoreService.findAllScores();
+        List<Score> foundScore = scoreService.findAllScores(true);
 
         assertFalse(foundScore.isEmpty());
         assertEquals(3, foundScore.size());
@@ -98,11 +98,11 @@ public class ScoreServiceImplTest {
     void ensureFindScoresFilterWorksAndReturnsFilteredByUserScores() {
         List<Score> scores = TestFixtures.scores(5);
 
-        when(scoreRepository.filterScores(10.0d,100.0d,1L,1L)).thenReturn(List.of(scores.get(0)));
+        when(scoreRepository.filterScores(10.0d,100.0d,1L,1L,true)).thenReturn(List.of(scores.get(0)));
 
         List<Score> foundScore = scoreService
                 .filterScores(10D,100D,
-                        1L,1L);
+                        1L,1L,true);
 
         assertFalse(foundScore.isEmpty());
         assertEquals(1, foundScore.size());
@@ -113,14 +113,14 @@ public class ScoreServiceImplTest {
     void ensureFindScoresFilterWorksAndReturnsFilteredByGameScores() {
         List<Score> scores = TestFixtures.scores(5);
 
-        when(scoreRepository.filterScores(10.0d,100.0d,null,1L)).thenReturn(scores);
+        when(scoreRepository.filterScores(10.0d,100.0d,null,1L,true)).thenReturn(scores);
 
         List<Score> foundScore = scoreService
-                .filterScores(10D,100D,null,1L);
+                .filterScores(10D,100D,null,1L,true);
 
         assertFalse(foundScore.isEmpty());
         assertEquals(5, scoreService
-                .filterScores(10D,100D, null,1L).size());
+                .filterScores(10D,100D, null,1L,true).size());
 
 
     }
@@ -143,9 +143,9 @@ public class ScoreServiceImplTest {
     void ensureFindScoresByUserWorksAndReturnsScores() {
         List<Score> scores = TestFixtures.scores(3);
 
-        when(scoreRepository.filterScores(null,null,2L,null)).thenReturn(List.of(scores.get(1)));
+        when(scoreRepository.filterScores(null,null,2L,null,true)).thenReturn(List.of(scores.get(1)));
 
-        List<Score> foundScore = scoreService.findScoresByUser(2L);
+        List<Score> foundScore = scoreService.findScoresByUser(2L,true);
 
         assertFalse(foundScore.isEmpty());
         assertEquals(scores.get(1).getUser().getId(), foundScore.getFirst().getUser().getId());
@@ -157,9 +157,9 @@ public class ScoreServiceImplTest {
     void ensureFindScoresByGameWorksAndReturnsScores() {
         List<Score> scores = TestFixtures.scores(3);
 
-        when(scoreRepository.filterScores(null,null,null,1L)).thenReturn(List.of(scores.getFirst()));
+        when(scoreRepository.filterScores(null,null,null,1L,true)).thenReturn(List.of(scores.getFirst()));
 
-        List<Score> foundScore = scoreService.findScoresByGame(1L);
+        List<Score> foundScore = scoreService.findScoresByGame(1L,true);
 
         assertFalse(foundScore.isEmpty());
         assertEquals(scores.getFirst().getUser().getId(), foundScore.getFirst().getUser().getId());
@@ -171,24 +171,24 @@ public class ScoreServiceImplTest {
     void ensureFindScoresByScorePointsWorksAndReturnsScoreByScores() {
         List<Score> scores = TestFixtures.scores(3);
 
-        when(scoreRepository.findScoreByScorePoints(10)).thenReturn(scores);
+        when(scoreRepository.findScoreByScorePoints(10,true)).thenReturn(scores);
 
-        List<Score> foundScore = scoreService.findScoreByScoresPoints(10);
+        List<Score> foundScore = scoreService.findScoreByScoresPoints(10,true);
 
         assertFalse(foundScore.isEmpty());
-        assertEquals(3, scoreService.findScoreByScoresPoints(10).size());
+        assertEquals(3, scoreService.findScoreByScoresPoints(10,true).size());
     }
 
     @Test
     void ensureFindScoresByMinMaxPointsWorksAndReturnsScore() {
         List<Score> scores = TestFixtures.scores(3);
 
-        when(scoreRepository.filterScores(11D,30D,null,null)).thenReturn(scores);
+        when(scoreRepository.filterScores(11D,30D,null,null,true)).thenReturn(scores);
 
-        List<Score> foundScore = scoreService.findScoreByMinMaxScoresPoints(11,30);
+        List<Score> foundScore = scoreService.findScoreByMinMaxScoresPoints(11,30,true);
 
         assertFalse(foundScore.isEmpty());
-        assertEquals(3, scoreService.findScoreByMinMaxScoresPoints(11,30).size());
+        assertEquals(3, scoreService.findScoreByMinMaxScoresPoints(11,30,true).size());
     }
 
     @Test

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
@@ -98,16 +98,14 @@ public class ScoreServiceImplTest {
     void ensureFindScoresFilterWorksAndReturnsFilteredByUserScores() {
         List<Score> scores = TestFixtures.scores(5);
 
-        when(scoreRepository.findScoreByMinMaxScorePoints(10.0d,100.0d)).thenReturn(scores);
+        when(scoreRepository.filterScores(10.0d,100.0d,1L,1L)).thenReturn(List.of(scores.get(0)));
 
         List<Score> foundScore = scoreService
-                .findScoresFilter(Optional.of(10D),Optional.of(100D),
-                        Optional.of(1L),Optional.of(1L));
+                .filterScores(10D,100D,
+                        1L,1L);
 
         assertFalse(foundScore.isEmpty());
-        assertEquals(1, scoreService
-                .findScoresFilter(Optional.of(10D),Optional.of(100D),
-                        Optional.of(1L),Optional.of(1L)).size());
+        assertEquals(1, foundScore.size());
 
 
     }
@@ -115,16 +113,14 @@ public class ScoreServiceImplTest {
     void ensureFindScoresFilterWorksAndReturnsFilteredByGameScores() {
         List<Score> scores = TestFixtures.scores(5);
 
-        when(scoreRepository.findScoreByMinMaxScorePoints(10.0d,100.0d)).thenReturn(scores);
+        when(scoreRepository.filterScores(10.0d,100.0d,null,1L)).thenReturn(scores);
 
         List<Score> foundScore = scoreService
-                .findScoresFilter(Optional.of(10D),Optional.of(100D),
-                        Optional.empty(),Optional.of(1L));
+                .filterScores(10D,100D,null,1L);
 
         assertFalse(foundScore.isEmpty());
         assertEquals(5, scoreService
-                .findScoresFilter(Optional.of(10D),Optional.of(100D),
-                        Optional.empty(),Optional.of(1L)).size());
+                .filterScores(10D,100D, null,1L).size());
 
 
     }

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
@@ -144,12 +144,12 @@ public class ScoreServiceImplTest {
     }
 
     @Test
-    void ensureFindScoreByUserWorksAndReturnsScore() {
+    void ensureFindScoresByUserWorksAndReturnsScores() {
         List<Score> scores = TestFixtures.scores(3);
 
         when(scoreRepository.findScoreByUser(2L)).thenReturn(List.of(scores.get(1)));
 
-        List<Score> foundScore = scoreService.findScoreByUser(2L);
+        List<Score> foundScore = scoreService.findScoresByUser(2L);
 
         assertFalse(foundScore.isEmpty());
         assertEquals(scores.get(1).getUser().getId(), foundScore.getFirst().getUser().getId());
@@ -158,12 +158,12 @@ public class ScoreServiceImplTest {
     }
 
     @Test
-    void ensureFindScoreByGameWorksAndReturnsScore() {
+    void ensureFindScoresByGameWorksAndReturnsScores() {
         List<Score> scores = TestFixtures.scores(3);
 
         when(scoreRepository.findScoreByGame(1L)).thenReturn(List.of(scores.getFirst()));
 
-        List<Score> foundScore = scoreService.findScoreByGame(1L);
+        List<Score> foundScore = scoreService.findScoresByGame(1L);
 
         assertFalse(foundScore.isEmpty());
         assertEquals(scores.getFirst().getUser().getId(), foundScore.getFirst().getUser().getId());
@@ -172,27 +172,27 @@ public class ScoreServiceImplTest {
     }
 
     @Test
-    void ensureFindScoreByScorePointsWorksAndReturnsScore() {
+    void ensureFindScoresByScorePointsWorksAndReturnsScoreByScores() {
         List<Score> scores = TestFixtures.scores(3);
 
         when(scoreRepository.findScoreByScorePoints(10)).thenReturn(scores);
 
-        List<Score> foundScore = scoreService.findScoreByScorePoints(10);
+        List<Score> foundScore = scoreService.findScoreByScoresPoints(10);
 
         assertFalse(foundScore.isEmpty());
-        assertEquals(3, scoreService.findScoreByScorePoints(10).size());
+        assertEquals(3, scoreService.findScoreByScoresPoints(10).size());
     }
 
     @Test
-    void ensureFindScoreByMinMaxPointsWorksAndReturnsScore() {
+    void ensureFindScoresByMinMaxPointsWorksAndReturnsScore() {
         List<Score> scores = TestFixtures.scores(3);
 
         when(scoreRepository.findScoreByMinMaxScorePoints(11,30)).thenReturn(scores);
 
-        List<Score> foundScore = scoreService.findScoreByMinMaxScorePoints(11,30);
+        List<Score> foundScore = scoreService.findScoreByMinMaxScoresPoints(11,30);
 
         assertFalse(foundScore.isEmpty());
-        assertEquals(3, scoreService.findScoreByMinMaxScorePoints(11,30).size());
+        assertEquals(3, scoreService.findScoreByMinMaxScoresPoints(11,30).size());
     }
 
     @Test

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/ScoreServiceImplTest.java
@@ -94,6 +94,40 @@ public class ScoreServiceImplTest {
         assertFalse(foundScore.isEmpty());
         assertEquals(3, foundScore.size());
     }
+    @Test
+    void ensureFindScoresFilterWorksAndReturnsFilteredByUserScores() {
+        List<Score> scores = TestFixtures.scores(5);
+
+        when(scoreRepository.findScoreByMinMaxScorePoints(10.0d,100.0d)).thenReturn(scores);
+
+        List<Score> foundScore = scoreService
+                .findScoresFilter(Optional.of(10D),Optional.of(100D),
+                        Optional.of(1L),Optional.of(1L));
+
+        assertFalse(foundScore.isEmpty());
+        assertEquals(1, scoreService
+                .findScoresFilter(Optional.of(10D),Optional.of(100D),
+                        Optional.of(1L),Optional.of(1L)).size());
+
+
+    }
+    @Test
+    void ensureFindScoresFilterWorksAndReturnsFilteredByGameScores() {
+        List<Score> scores = TestFixtures.scores(5);
+
+        when(scoreRepository.findScoreByMinMaxScorePoints(10.0d,100.0d)).thenReturn(scores);
+
+        List<Score> foundScore = scoreService
+                .findScoresFilter(Optional.of(10D),Optional.of(100D),
+                        Optional.empty(),Optional.of(1L));
+
+        assertFalse(foundScore.isEmpty());
+        assertEquals(5, scoreService
+                .findScoresFilter(Optional.of(10D),Optional.of(100D),
+                        Optional.empty(),Optional.of(1L)).size());
+
+
+    }
 
     @Test
     void ensureFindScoreByIdWorksAndReturnsScore() {

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/UserServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/UserServiceImplTest.java
@@ -89,7 +89,7 @@ public class UserServiceImplTest {
         User user = TestFixtures.user(1L);
 
         when(userRepository.findUserById(user.getId())).thenReturn(Optional.of(user));
-        when(scoreService.findScoresByUser(user.getId())).thenReturn(List.of());
+        when(scoreService.findScoresByUser(user.getId(),true)).thenReturn(List.of());
 
         Optional<User> deletedUser = userService.deleteUser(user.getId());
         assertTrue(deletedUser.isPresent());
@@ -102,7 +102,7 @@ public class UserServiceImplTest {
         Score score = TestFixtures.score(1L,1L,1L);
 
         when(userRepository.findUserById(user.getId())).thenReturn(Optional.of(user));
-        when(scoreService.findScoresByUser(user.getId())).thenReturn(List.of(score));
+        when(scoreService.findScoresByUser(user.getId(),true)).thenReturn(List.of(score));
 
         Optional<User> deletedUser = userService.deleteUser(user.getId());
         assertTrue(deletedUser.isPresent());

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/UserServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/UserServiceImplTest.java
@@ -89,7 +89,7 @@ public class UserServiceImplTest {
         User user = TestFixtures.user(1L);
 
         when(userRepository.findUserById(user.getId())).thenReturn(Optional.of(user));
-        when(scoreService.findScoreByUser(user.getId())).thenReturn(List.of());
+        when(scoreService.findScoresByUser(user.getId())).thenReturn(List.of());
 
         Optional<User> deletedUser = userService.deleteUser(user.getId());
         assertTrue(deletedUser.isPresent());
@@ -102,7 +102,7 @@ public class UserServiceImplTest {
         Score score = TestFixtures.score(1L,1L,1L);
 
         when(userRepository.findUserById(user.getId())).thenReturn(Optional.of(user));
-        when(scoreService.findScoreByUser(user.getId())).thenReturn(List.of(score));
+        when(scoreService.findScoresByUser(user.getId())).thenReturn(List.of(score));
 
         Optional<User> deletedUser = userService.deleteUser(user.getId());
         assertTrue(deletedUser.isPresent());


### PR DESCRIPTION
finished multiple query-parameter for matches & scores before refectoring the project structure

[add multi query-parameters for score filtering](https://github.com/Gepardec/gepardec-gamertrack/commit/9e9635409761b9bdf4bc313d3f477510307f3ded) 

[remove unnecessary Score-Endpoints](https://github.com/Gepardec/gepardec-gamertrack/commit/0a73d523925738ce4354eaedee501591d3667c91) 

[rework http response code and Rest-Endpoints description](https://github.com/Gepardec/gepardec-gamertrack/commit/650809eb9d9ca4b9a540124316003ab1bc0adfe0) 

[Fix getMatches not working as expected when both params are set](https://github.com/Gepardec/gepardec-gamertrack/commit/a1a57dbe8cae5ee828d99356f87d943a81e6335f) 

[add FilterTest for ScoreServiceImplTest](https://github.com/Gepardec/gepardec-gamertrack/commit/3b298ccd7448cda1d5596373cd45948bfb2414de) 

[add MatchServiceImplTest for findMatchByUserIdAndGameId](https://github.com/Gepardec/gepardec-gamertrack/commit/e5edac5de690a026e7aee74abf5bec3e097a1a7a) 

[refactor matchService and matchRepository methods naming to plural if…](https://github.com/Gepardec/gepardec-gamertrack/commit/152f6e775fb2b7d8517bc47a93735da1bfbb09bf) 

[refactor ScoreService methodnames for plural if lists are returned](https://github.com/Gepardec/gepardec-gamertrack/commit/c633aa755449be0085a40ba5dd92da75297f2354) 

[rework filterScore to filter from repo](https://github.com/Gepardec/gepardec-gamertrack/commit/39c86205b34e5b6fd1b1970ad720059a034a21ac) 

[remove unnecessary score filter method](https://github.com/Gepardec/gepardec-gamertrack/commit/fbaa14f1ed1a77c2d59f42c2ad6f0474c2d36552) 

[reworked FilterScores-methods of ScoreServiceImplTest](https://github.com/Gepardec/gepardec-gamertrack/commit/ae0fd26523c8d3c6eface64631e8ab2d4eaf2996)


closes issue:
closes #19 