### PR TITLE
PR: Sort users by match count when all returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ e.g
 
 or any other wildfly location
 
+## secret.env
+
+The project/application needs a secret.env file with the following variables set in order for authentication and tests to work
+
+```
+SECRET_ADMIN_NAME
+SECRET_JWT_HASH
+SECRET_DEFAULT_PW
+```
+
+For convenience the [plugin](https://plugins.jetbrains.com/plugin/7861-envfile) is recommended for reading the secret.env when tests are executed via IntelliJ 
+
 ## Build Project and deploy application
 
 - *In order for all used relative paths to work  

--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/config/filters/response/CorsResponseFilterIT.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/config/filters/response/CorsResponseFilterIT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static com.gepardec.rest.config.filters.response.CorsResponseFilter.*;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.nullValue;
@@ -13,9 +14,6 @@ public class CorsResponseFilterIT {
 
     private final String VALID_ORIGIN = "http://gamertrack-frontend.apps.cloudscale-lpg-2.appuio.cloud";
     private final String INVALID_ORIGIN = "http://lkadsjlksjdfgamertrack-frontend.apps.cloudscale-lpg-2.appuio.com";
-    private final String ALLOWED_METHODS = "GET, POST, PUT, DELETE, HEAD";
-    private final String ALLOWED_HEADERS = "Content-Type, Authorization";
-    private final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "true";
 
     @BeforeAll
     public static void setup() {
@@ -40,7 +38,8 @@ public class CorsResponseFilterIT {
                 .header("Access-Control-Allow-Origin", VALID_ORIGIN)
                 .header("Access-Control-Allow-Methods", ALLOWED_METHODS)
                 .header("Access-Control-Allow-Headers", ALLOWED_HEADERS)
-                .header("Access-Control-Allow-Credentials", ACCESS_CONTROL_ALLOW_CREDENTIALS);
+                .header("Access-Control-Allow-Credentials", ACCESS_CONTROL_ALLOW_CREDENTIALS_IS_ALLOWED)
+                .header("Access-Control-Expose-Headers", ACCESS_CONTROL_EXPOSE_HEADERS);
     }
 
     @Test
@@ -53,8 +52,8 @@ public class CorsResponseFilterIT {
                 .header("Access-Control-Allow-Origin", VALID_ORIGIN.replace("http", "https"))
                 .header("Access-Control-Allow-Methods", ALLOWED_METHODS)
                 .header("Access-Control-Allow-Headers", ALLOWED_HEADERS)
-                .header("Access-Control-Allow-Credentials", ACCESS_CONTROL_ALLOW_CREDENTIALS);
-        ;
+                .header("Access-Control-Allow-Credentials", ACCESS_CONTROL_ALLOW_CREDENTIALS_IS_ALLOWED)
+                .header("Access-Control-Expose-Headers", ACCESS_CONTROL_EXPOSE_HEADERS);
     }
 
     @Test
@@ -67,8 +66,8 @@ public class CorsResponseFilterIT {
                 .header("Access-Control-Allow-Origin", nullValue())
                 .header("Access-Control-Allow-Methods", nullValue())
                 .header("Access-Control-Allow-Headers", nullValue())
-                .header("Access-Control-Allow-Credentials", nullValue());
-        ;
+                .header("Access-Control-Allow-Credentials", nullValue())
+                .header("Access-Control-Expose-Headers", nullValue());
     }
 
     @Test
@@ -81,7 +80,8 @@ public class CorsResponseFilterIT {
                 .header("Access-Control-Allow-Origin", VALID_ORIGIN)
                 .header("Access-Control-Allow-Methods", ALLOWED_METHODS)
                 .header("Access-Control-Allow-Headers", ALLOWED_HEADERS)
-                .header("Access-Control-Allow-Credentials", ACCESS_CONTROL_ALLOW_CREDENTIALS)
+                .header("Access-Control-Allow-Credentials", ACCESS_CONTROL_ALLOW_CREDENTIALS_IS_ALLOWED)
+                .header("Access-Control-Expose-Headers", ACCESS_CONTROL_EXPOSE_HEADERS)
                 .body(blankOrNullString());
     }
 }

--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/RestTestFixtures.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/RestTestFixtures.java
@@ -42,7 +42,7 @@ public class RestTestFixtures {
 
   public static MatchRestDto matchRestDto(String token, GameRestDto gameRestDto,
       List<UserRestDto> userRestDtos) {
-    return new MatchRestDto(token, gameRestDto, userRestDtos);
+    return new MatchRestDto(token, "2025-01-01 12:12:12","2025-01-01 12:12:12", gameRestDto, userRestDtos);
   }
 
   public static Game game() {

--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/UserResourceImplIT.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/UserResourceImplIT.java
@@ -126,6 +126,13 @@ public class UserResourceImplIT {
 
                 with()
                         .when()
+                        .headers(
+                                "Authorization",
+                                "Bearer " + bearerToken,
+                                "Content-Type",
+                                ContentType.JSON,
+                                "Accept",
+                                ContentType.JSON)
                         .contentType("application/json")
                         .pathParam("token", token)
                         .request("GET", "/users/{token}")
@@ -212,6 +219,13 @@ public class UserResourceImplIT {
         @Test
         public void ensureGetUserReturnsOk() {
                 with().when()
+                        .headers(
+                                "Authorization",
+                                "Bearer " + bearerToken,
+                                "Content-Type",
+                                ContentType.JSON,
+                                "Accept",
+                                ContentType.JSON)
                         .request("GET", "/users")
                         .then()
                         .statusCode(200);
@@ -241,6 +255,13 @@ public class UserResourceImplIT {
                 with()
                         .when()
                         .contentType("application/json")
+                        .headers(
+                                "Authorization",
+                                "Bearer " + bearerToken,
+                                "Content-Type",
+                                ContentType.JSON,
+                                "Accept",
+                                ContentType.JSON)
                         .pathParam("token", token)
                         .request("GET", "/users/{token}")
                         .then()
@@ -289,6 +310,13 @@ public class UserResourceImplIT {
                         .statusCode(200);
 
                 with().when()
+                        .headers(
+                                "Authorization",
+                                "Bearer " + bearerToken,
+                                "Content-Type",
+                                ContentType.JSON,
+                                "Accept",
+                                ContentType.JSON)
                         .request("GET", "/users?includeDeactivated=false")
                         .then()
                         .body("token", not(hasItem(token)))
@@ -333,6 +361,13 @@ public class UserResourceImplIT {
                         .statusCode(200);
 
                 with().when()
+                        .headers(
+                                "Authorization",
+                                "Bearer " + bearerToken,
+                                "Content-Type",
+                                ContentType.JSON,
+                                "Accept",
+                                ContentType.JSON)
                         .request("GET", "/users?includeDeactivated=true")
                         .then()
                         .body("token", hasItem(token))

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/AuthResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/AuthResource.java
@@ -1,6 +1,7 @@
 package com.gepardec.rest.api;
 
 import com.gepardec.rest.model.command.AuthCredentialCommand;
+import com.gepardec.rest.model.command.ValidateTokenCommand;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -16,4 +17,8 @@ public interface AuthResource {
     @POST
     @Path("/login")
     Response login(AuthCredentialCommand authCredentialCommand);
+
+    @POST
+    @Path("/validate")
+    Response validateToken(ValidateTokenCommand token);
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/UserResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/UserResource.java
@@ -54,6 +54,7 @@ public interface UserResource {
             @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
             @ApiResponse(responseCode = "204", description = "No Content - No users were found")
     })    @GET
+    @Secure
     public Response getUsers(@QueryParam("includeDeactivated") @DefaultValue(value = "true") Boolean includeDeactivated);
 
     @Operation(summary = "Get User by token", description = "Returns user by token")
@@ -62,6 +63,7 @@ public interface UserResource {
     })
     @Path("{token}")
     @GET
+    @Secure
     public Response getUser(@PathParam("token") String token);
 
 

--- a/gamertrack-application/src/main/java/com/gepardec/rest/config/filters/response/CorsResponseFilter.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/config/filters/response/CorsResponseFilter.java
@@ -11,6 +11,12 @@ import java.io.IOException;
 @Provider
 public class CorsResponseFilter implements ContainerResponseFilter {
 
+    protected static final String ALLOWED_METHODS = "GET, POST, PUT, DELETE, HEAD";
+    protected static final String ALLOWED_HEADERS = "Content-Type, Authorization";
+    protected static final String ACCESS_CONTROL_ALLOW_CREDENTIALS_IS_ALLOWED = "true";
+    protected static final String ACCESS_CONTROL_EXPOSE_HEADERS =  "x-total-count, x-total-pages, x-page-size, x-current-page, Authorization";
+
+
     Dotenv dotenv = Dotenv
             .configure()
             .directory("../..")
@@ -25,9 +31,10 @@ public class CorsResponseFilter implements ContainerResponseFilter {
 
         if (origin != null && origin.matches(dotenv.get("ALLOWED_ORIGINS_AS_REGEX"))) {
             responseContext.getHeaders().add("Access-Control-Allow-Origin", origin);
-            responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, HEAD");
-            responseContext.getHeaders().add("Access-Control-Allow-Headers", "Content-Type, Authorization");
-            responseContext.getHeaders().add("Access-Control-Allow-Credentials", true);
+            responseContext.getHeaders().add("Access-Control-Allow-Methods", ALLOWED_METHODS);
+            responseContext.getHeaders().add("Access-Control-Allow-Headers", ALLOWED_HEADERS);
+            responseContext.getHeaders().add("Access-Control-Allow-Credentials", ACCESS_CONTROL_ALLOW_CREDENTIALS_IS_ALLOWED);
+            responseContext.getHeaders().add("Access-Control-Expose-Headers", ACCESS_CONTROL_EXPOSE_HEADERS);
         }
     }
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/config/filters/response/XTotalCountResponseFilter.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/config/filters/response/XTotalCountResponseFilter.java
@@ -14,8 +14,8 @@ public class XTotalCountResponseFilter implements ContainerResponseFilter {
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
         var body = responseContext.getEntity();
 
-        if (!responseContext.getHeaders().containsKey("X-Total-Count") && body instanceof Collection) {
-            responseContext.getHeaders().add("X-Total-Count", ((Collection<?>) body).size());
+        if (!responseContext.getHeaders().containsKey("x-total-count".toLowerCase()) && body instanceof Collection) {
+            responseContext.getHeaders().add("x-total-count".toLowerCase(), ((Collection<?>) body).size());
         }
 
     }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/config/listeners/StartupListener.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/config/listeners/StartupListener.java
@@ -1,0 +1,24 @@
+package com.gepardec.rest.config.listeners;
+
+import com.gepardec.core.services.AuthService;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+
+@WebListener
+public class StartupListener implements ServletContextListener {
+
+    @Inject
+    private AuthService authService;
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        authService.createDefaultUserIfNotExists();
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        // Do something on shutdown
+    }
+}

--- a/gamertrack-application/src/main/java/com/gepardec/rest/config/listeners/StartupListener.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/config/listeners/StartupListener.java
@@ -14,9 +14,7 @@ public class StartupListener implements ServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        authService.createDefaultUserIfNotExists();
-
-
+        authService.createDefaultUser();
     }
 
     @Override

--- a/gamertrack-application/src/main/java/com/gepardec/rest/config/listeners/StartupListener.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/config/listeners/StartupListener.java
@@ -15,6 +15,8 @@ public class StartupListener implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent sce) {
         authService.createDefaultUserIfNotExists();
+
+
     }
 
     @Override

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
@@ -27,7 +27,6 @@ public class AuthResourceImpl implements AuthResource {
 
     @Override
     public Response login(AuthCredentialCommand authCredentialCommand) {
-        authService.createDefaultUserIfNotExists();
         if (authService.authenticate(mapper.authCredentialCommandToAuthCredential(authCredentialCommand))) {
 
             String token = jwtUtil.generateToken(authCredentialCommand.username());

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
@@ -3,6 +3,7 @@ package com.gepardec.rest.impl;
 import com.gepardec.core.services.AuthService;
 import com.gepardec.rest.api.AuthResource;
 import com.gepardec.rest.model.command.AuthCredentialCommand;
+import com.gepardec.rest.model.command.ValidateTokenCommand;
 import com.gepardec.rest.model.mapper.AuthCredentialRestMapper;
 import com.gepardec.security.JwtUtil;
 import jakarta.enterprise.context.RequestScoped;
@@ -35,5 +36,12 @@ public class AuthResourceImpl implements AuthResource {
         } else {
             return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid credentials").build();
         }
+    }
+
+    @Override
+    public Response validateToken(ValidateTokenCommand tokenCmd) {
+        if (tokenCmd.token() != null && authService.isTokenValid(tokenCmd.token())) return Response.ok().build();
+
+        return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid token").build();
     }
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
@@ -27,13 +27,10 @@ public class AuthResourceImpl implements AuthResource {
 
     @Override
     public Response login(AuthCredentialCommand authCredentialCommand) {
-        long start = System.nanoTime();
         if (authService.authenticate(mapper.authCredentialCommandToAuthCredential(authCredentialCommand))) {
 
             String token = jwtUtil.generateToken(authCredentialCommand.username());
 
-            long end = System.nanoTime();
-            System.out.println("Time until response is started to be built: " + (end - start) / 1000000 + "ms");
             return Response.ok("{\"token\": \"" + token + "\"}").header(AUTHORIZATION, "Bearer " + token).build();
         } else {
             return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid credentials").build();

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
@@ -27,10 +27,13 @@ public class AuthResourceImpl implements AuthResource {
 
     @Override
     public Response login(AuthCredentialCommand authCredentialCommand) {
+        long start = System.nanoTime();
         if (authService.authenticate(mapper.authCredentialCommandToAuthCredential(authCredentialCommand))) {
 
             String token = jwtUtil.generateToken(authCredentialCommand.username());
 
+            long end = System.nanoTime();
+            System.out.println("Time until response is started to be built: " + (end - start) / 1000000 + "ms");
             return Response.ok("{\"token\": \"" + token + "\"}").header(AUTHORIZATION, "Bearer " + token).build();
         } else {
             return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid credentials").build();

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/MatchResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/MatchResourceImpl.java
@@ -45,10 +45,10 @@ public class MatchResourceImpl implements MatchResource {
 
     public Response createPaginatedResponse(long totalData, PageRequest pageRequest, List<Match> bodyData) {
         return Response.ok()
-                .header("X-Total-Count", totalData)
-                .header("X-Total-Pages", (int) ceil((double) totalData / pageRequest.size()))
-                .header("X-Page-Size", pageRequest.size())
-                .header("X-Current-Page", pageRequest.page())
+                .header("X-Total-Count".toLowerCase(), totalData)
+                .header("X-Total-Pages".toLowerCase(), (int) ceil((double) totalData / pageRequest.size()))
+                .header("X-Page-Size".toLowerCase(), pageRequest.size())
+                .header("X-Current-Page".toLowerCase(), pageRequest.page())
                 .entity(bodyData.stream()
                         .map(MatchRestDto::new)
                         .toList())

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/MatchResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/MatchResourceImpl.java
@@ -36,6 +36,13 @@ public class MatchResourceImpl implements MatchResource {
         PageRequest pageRequest = PageRequest.ofPage(pageNumber.orElse(1L), pageSize.orElse(Integer.MAX_VALUE), true);
 
         logger.info("Getting matches with filter gameToken: %s, userToken: %s".formatted(gameToken, userToken));
+
+        System.out.println(createPaginatedResponse(
+                matchService.countAllFilteredOrUnfilteredMatches(gameToken, userToken),
+                pageRequest,
+                matchService.findAllFilteredOrUnfilteredMatches(gameToken, userToken, pageRequest)
+        ).toString());
+
         return createPaginatedResponse(
                 matchService.countAllFilteredOrUnfilteredMatches(gameToken, userToken),
                 pageRequest,

--- a/gamertrack-application/src/main/java/com/gepardec/rest/model/command/ValidateTokenCommand.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/model/command/ValidateTokenCommand.java
@@ -1,0 +1,5 @@
+package com.gepardec.rest.model.command;
+
+public record ValidateTokenCommand(String token) {
+
+}

--- a/gamertrack-application/src/main/java/com/gepardec/rest/model/dto/MatchRestDto.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/model/dto/MatchRestDto.java
@@ -4,15 +4,18 @@ import com.gepardec.model.Match;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public record MatchRestDto(@NotBlank String token, @NotNull GameRestDto game,
+public record MatchRestDto(@NotBlank String token, @NotNull String createdOn, String updatedOn, @NotNull GameRestDto game,
                            @NotNull List<UserRestDto> users) {
 
     public MatchRestDto(Match match) {
         this(match.getToken(),
+                match.getUpdatedOn().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                match.getUpdatedOn().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
                 new GameRestDto(match.getGame()),
                 new ArrayList<>(
                         match.getUsers().stream()
@@ -28,12 +31,12 @@ public record MatchRestDto(@NotBlank String token, @NotNull GameRestDto game,
         }
         MatchRestDto that = (MatchRestDto) o;
         return Objects.equals(game, that.game) && Objects.equals(token, that.token)
-                && Objects.equals(users, that.users);
+                && Objects.equals(users, that.users) && Objects.equals(createdOn, that.createdOn) && Objects.equals(updatedOn, that.updatedOn);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(token, game, users);
+        return Objects.hash(token, game, users,createdOn, updatedOn);
     }
 
     @Override

--- a/gamertrack-application/src/test/java/com/gepardec/RestTestFixtures.java
+++ b/gamertrack-application/src/test/java/com/gepardec/RestTestFixtures.java
@@ -47,7 +47,7 @@ public class RestTestFixtures {
 
 
   public static MatchRestDto matchRestDto(String token, GameRestDto gameRestDto, List<UserRestDto> userRestDtos) {
-      return new MatchRestDto(token, gameRestDto, userRestDtos);
+      return new MatchRestDto(token, "2025-01-01 12:12:12","2025-01-01 12:12:12", gameRestDto, userRestDtos);
   }
 
   public static Game game() {

--- a/gamertrack-db/pom.xml
+++ b/gamertrack-db/pom.xml
@@ -51,6 +51,13 @@
       <version>5.1.0.Beta7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hibernate.orm</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>6.6.10.Final</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/entity/AbstractEntity.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/entity/AbstractEntity.java
@@ -1,6 +1,8 @@
 package com.gepardec.adapter.output.persistence.entity;
 
 import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -14,7 +16,9 @@ public class AbstractEntity implements Serializable {
     @Version
     protected Long version;
 
+    @CreationTimestamp
     protected LocalDateTime createdOn;
+    @UpdateTimestamp
     protected LocalDateTime updatedOn;
 
     public Long getId() {

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/entity/MatchEntity.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/entity/MatchEntity.java
@@ -26,8 +26,8 @@ public class MatchEntity extends AbstractEntity {
 
   @ManyToMany(cascade = CascadeType.MERGE, fetch = FetchType.EAGER)
   @JoinTable(name = "matches_users", joinColumns =
-  @JoinColumn(nullable = false, name = "fk_user", foreignKey = @ForeignKey(name = "fk_user")), inverseJoinColumns =
-  @JoinColumn(nullable = false, name = "fk_match", foreignKey = @ForeignKey(name = "fk_match")))
+  @JoinColumn(nullable = false, name = "fk_match", foreignKey = @ForeignKey(name = "fk_match")), inverseJoinColumns =
+  @JoinColumn(nullable = false, name = "fk_user", foreignKey = @ForeignKey(name = "fk_user")))
   private List<UserEntity> users;
 
   public MatchEntity() {

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/AuthRepositoryImpl.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/AuthRepositoryImpl.java
@@ -40,16 +40,18 @@ public class AuthRepositoryImpl implements AuthRepository, Serializable {
     }
 
     @Override
-    public boolean createDefaultUserIfNotExists(AuthCredential authCredential){
+    public Optional<AuthCredential> createDefaultUser(AuthCredential authCredential){
         AuthCredentialEntity authCredentialEntity = authCredentialMapper.authCredentialModelToAuthCredentialEntity(authCredential);
         entityManager.persist(authCredentialEntity);
-        return true;
+
+        return entityManager.find(AuthCredentialEntity.class, authCredentialEntity.getId()) != null
+        ? Optional.of(authCredentialMapper.authCredentialEntityToAuthCredentialModel(authCredentialEntity))
+        : Optional.empty();
     }
 
+
     @Override
-    public void updateDefaultUserPassword(AuthCredential authCredential) {
-        AuthCredentialEntity authCredentialEntity = authCredentialMapper.authCredentialModeltoExistingauthCredentialEntity(
-                authCredential,entityManager.find(AuthCredentialEntity.class, findByUsername(authCredential.getUsername()).get().getId()));
-        entityManager.merge(authCredentialEntity);
+    public void deleteExistingAuthUsers() {
+        entityManager.createQuery("DELETE FROM AuthCredentialEntity").executeUpdate();
     }
 }

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/mapper/AuthCredentialMapper.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/mapper/AuthCredentialMapper.java
@@ -16,6 +16,7 @@ public class AuthCredentialMapper {
     }
     public AuthCredentialEntity authCredentialModeltoExistingauthCredentialEntity(AuthCredential authCredential, AuthCredentialEntity authCredentialEntity) {
         authCredentialEntity.setPassword(authCredential.getPassword());
+        authCredentialEntity.setSalt(authCredential.getSalt());
         return authCredentialEntity;
     }
 }

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/mapper/MatchMapper.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/mapper/MatchMapper.java
@@ -30,10 +30,6 @@ public class MatchMapper {
   }
 
   public Match matchEntityToMatchModel(MatchEntity matchEntity) {
-    System.out.println("createdOn is: "+matchEntity.getCreatedOn());
-    System.out.println("createdOn is: "+matchEntity.getCreatedOn().getClass());
-    System.out.println("UpdatedOn is: "+matchEntity.getUpdatedOn());
-    System.out.println("UpdatedOn is: "+matchEntity.getUpdatedOn().getClass());
 
     return new Match(matchEntity.getId(), matchEntity.getToken(),
             matchEntity.getCreatedOn(), matchEntity.getUpdatedOn(),

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/mapper/MatchMapper.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/mapper/MatchMapper.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,8 +30,14 @@ public class MatchMapper {
   }
 
   public Match matchEntityToMatchModel(MatchEntity matchEntity) {
+    System.out.println("createdOn is: "+matchEntity.getCreatedOn());
+    System.out.println("createdOn is: "+matchEntity.getCreatedOn().getClass());
+    System.out.println("UpdatedOn is: "+matchEntity.getUpdatedOn());
+    System.out.println("UpdatedOn is: "+matchEntity.getUpdatedOn().getClass());
+
     return new Match(matchEntity.getId(), matchEntity.getToken(),
-        gameMapper.gameEntityToGameModel(matchEntity.getGame()),
+            matchEntity.getCreatedOn(), matchEntity.getUpdatedOn(),
+            gameMapper.gameEntityToGameModel(matchEntity.getGame()),
         matchEntity.getUsers().stream().map(userMapper::userEntityToUserModel).toList());
   }
 

--- a/gamertrack-db/src/test/java/com/gepardec/adapter/output/persistence/repository/AuthRepositoryTest.java
+++ b/gamertrack-db/src/test/java/com/gepardec/adapter/output/persistence/repository/AuthRepositoryTest.java
@@ -10,8 +10,7 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -29,8 +28,32 @@ public class AuthRepositoryTest extends GamertrackDbIT {
     void ensureCreateDefaultUserWorks() {
         AuthCredential authCredential = new AuthCredential(tokenService.generateToken(), "admin",
                 "password", "salt");
-        assertTrue(authRepository.createDefaultUserIfNotExists(authCredential));
+
+        authRepository.createDefaultUser(authCredential);
+
+        assertTrue(authRepository.findByUsername(authCredential.getUsername()).isPresent());
+        assertEquals("admin", authRepository.findByUsername(authCredential.getUsername()).get().getUsername());
     }
+
+    @Test
+    void ensureCreateDefaultUserWorksIfUserAlreadyExists() {
+        //GIVEN
+        AuthCredential existingAuthCredential = new AuthCredential(tokenService.generateToken(), "oldAdmin",
+                "password", "salt");
+        authRepository.createDefaultUser(existingAuthCredential);
+
+
+        //WHEN
+        AuthCredential newAuthCredential = new AuthCredential(tokenService.generateToken(), "newAdmin",
+                "password", "salt");
+
+
+        //THEN
+
+        assertTrue(authRepository.findByUsername(existingAuthCredential.getUsername()).isPresent());
+        assertFalse(authRepository.findByUsername(newAuthCredential.getUsername()).isPresent());
+        }
+
 
     @Test
     void ensureFindByUsernameReturnsEmpty() {
@@ -44,7 +67,7 @@ public class AuthRepositoryTest extends GamertrackDbIT {
         AuthCredential authCredential = new AuthCredential(tokenService.generateToken(), "CorrectName",
                 "password", "salt");
 
-        authRepository.createDefaultUserIfNotExists(authCredential);
+        authRepository.createDefaultUser(authCredential);
 
         assertEquals("CorrectName", authRepository.findByUsername(authCredential.getUsername()).get().getUsername());
     }

--- a/gamertrack-domain/pom.xml
+++ b/gamertrack-domain/pom.xml
@@ -71,6 +71,35 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>read-project-properties</goal>
+            </goals>
+            <configuration>
+              <quiet>true</quiet>
+              <files>
+              <file>${project.parent.basedir}/secret.env</file>
+              </files>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+        <configuration>
+          <environmentVariables>
+            <SECRET_JWT_HASH>${SECRET_JWT_HASH}</SECRET_JWT_HASH>
+          </environmentVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/gamertrack-domain/src/main/java/com/gepardec/core/repository/AuthRepository.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/repository/AuthRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface AuthRepository {
     Optional<AuthCredential> findByUsername(String username);
-    boolean createDefaultUserIfNotExists(AuthCredential authCredential);
-    void updateDefaultUserPassword(AuthCredential authCredential);
+    Optional<AuthCredential> createDefaultUser(AuthCredential authCredential);
+    void deleteExistingAuthUsers();
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/core/repository/UserRepository.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/repository/UserRepository.java
@@ -10,12 +10,7 @@ public interface UserRepository {
   Optional<User> saveUser(User user);
   Optional<User> updateUser(User user);
   void deleteUser(User user);
-  /**
-   * deleteAllUsers - Only for testing purposes
-   */
-  void deleteAllUsers();
-  List<User> findAllUsers(boolean includeDeactivatedUsers);
+  List<User> findAllUsersSortedByMatchCount(boolean includeDeactivatedUsers);
   Optional<User> findUserByToken(String token);
   Boolean existsByUserToken(List<String> userTokens);
-
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/AuthService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/AuthService.java
@@ -4,6 +4,6 @@ import com.gepardec.model.AuthCredential;
 
 public interface AuthService {
     boolean authenticate(AuthCredential credential);
-    boolean createDefaultUserIfNotExists();
+    void createDefaultUser();
     boolean isTokenValid(String token);
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/AuthService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/AuthService.java
@@ -5,4 +5,5 @@ import com.gepardec.model.AuthCredential;
 public interface AuthService {
     boolean authenticate(AuthCredential credential);
     boolean createDefaultUserIfNotExists();
+    boolean isTokenValid(String token);
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/AuthServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/AuthServiceImpl.java
@@ -57,28 +57,16 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public boolean createDefaultUserIfNotExists() {
+    public void createDefaultUser() {
         Map<String, String> credMap = jwtUtil.calcHashedCredentialMap(SECRET_DEFAULT_PW);
 
         AuthCredential credential = new AuthCredential(tokenService.generateToken(),SECRET_ADMIN_NAME,
                 credMap.get("hashedPassword"), credMap.get("salt"));
 
-        Optional<AuthCredential> dbAuthCredentialEntity = authRepository.findByUsername(credential.getUsername());
+        authRepository.deleteExistingAuthUsers();
 
-        if (!dbAuthCredentialEntity.isPresent()) {
-            authRepository.createDefaultUserIfNotExists(credential);
-            credMap = null;
+        if (authRepository.createDefaultUser(credential).isPresent())
             log.info("Default user created");
-            return true; //user was created
-        }
-        else{
-            log.info("Default user exists");
-            if(!jwtUtil.passwordsMatches(dbAuthCredentialEntity.get().getPassword(), dbAuthCredentialEntity.get().getSalt(),SECRET_DEFAULT_PW)){
-                authRepository.updateDefaultUserPassword(credential);
-                log.info("Default user password was updated!");
-            }
-            return false; //user was not created
-        }
     }
 
     @Override

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/AuthServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/AuthServiceImpl.java
@@ -6,6 +6,8 @@ import com.gepardec.core.services.TokenService;
 import com.gepardec.model.AuthCredential;
 import com.gepardec.security.JwtUtil;
 import io.github.cdimascio.dotenv.Dotenv;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -77,5 +79,17 @@ public class AuthServiceImpl implements AuthService {
             }
             return false; //user was not created
         }
+    }
+
+    @Override
+    public boolean isTokenValid(String token) {
+        boolean isValid = false;
+        try {
+            Jwts.parser().setSigningKey(jwtUtil.generateKey()).build().parseClaimsJws(token);
+            isValid = true;
+        } catch (JwtException e) {
+            log.error("Token validation failed {}", e.getMessage());
+        }
+        return isValid;
     }
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/UserServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/UserServiceImpl.java
@@ -85,7 +85,7 @@ public class UserServiceImpl implements UserService, Serializable {
 
     @Override
     public List<User> findAllUsers(boolean includeDeactivated) {
-        return userRepository.findAllUsers(includeDeactivated);
+        return userRepository.findAllUsersSortedByMatchCount(includeDeactivated);
     }
 
     @Override

--- a/gamertrack-domain/src/main/java/com/gepardec/model/Match.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/model/Match.java
@@ -3,6 +3,7 @@ package com.gepardec.model;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -14,8 +15,19 @@ public class Match {
     private Game game;
     @NotEmpty(message = "User List must not be null or Empty")
     private List<User> users;
+    private LocalDateTime createdOn;
+    private LocalDateTime updatedOn;
 
     public Match() {
+    }
+
+    public Match(Long id, String token, LocalDateTime createdOn, LocalDateTime updatedOn, Game game, List<User> users) {
+        this.id = id;
+        this.token = token;
+        this.createdOn = createdOn;
+        this.updatedOn = updatedOn;
+        this.game = game;
+        this.users = users;
     }
 
     public Match(Long id, String token, Game game, List<User> users) {
@@ -55,6 +67,22 @@ public class Match {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public LocalDateTime getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(LocalDateTime createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public LocalDateTime getUpdatedOn() {
+        return updatedOn;
+    }
+
+    public void setUpdatedOn(LocalDateTime updatedOn) {
+        this.updatedOn = updatedOn;
     }
 
     @Override

--- a/gamertrack-domain/src/main/java/com/gepardec/security/JwtUtil.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/security/JwtUtil.java
@@ -21,25 +21,19 @@ public class JwtUtil {
     private static final String SECRET_KEY = dotenv.get("SECRET_JWT_HASH", System.getenv("SECRET_JWT_HASH"));
 
     public String generateToken(String username) {
-        long start = System.nanoTime();
         var jwt = Jwts.builder()
                 .setSubject(username)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 720))
                 .signWith(SignatureAlgorithm.HS512, generateKey())
                 .compact();
 
-        long end = System.nanoTime();
-        System.out.println("Time to generate token: " + (end - start) / 1000000 + "ms");
         return jwt;
     }
 
     public boolean passwordsMatches(String dbHashedPassword, String saltText, String clearTextPassword) {
-        long start = System.nanoTime();
         ByteSource salt = ByteSource.Util.bytes(Hex.decode(saltText));
         String hashedPassword = hashAndSaltPassword(clearTextPassword, salt);
-        long end = System.nanoTime();
-        System.out.println("Time to hash and salt password: " + (end - start) / 1000000 + "ms");
         return hashedPassword.equals(dbHashedPassword);
     }
 
@@ -62,10 +56,6 @@ public class JwtUtil {
     }
 
     public Key generateKey() {
-        long start = System.nanoTime();
-        var temp = new SecretKeySpec(SECRET_KEY.getBytes(), 0, SECRET_KEY.getBytes().length, "HmacSHA512");
-        long end = System.nanoTime();
-        System.out.println("Time to generate key: " + (end - start) / 1000000 + "ms");
-        return temp;
+        return new SecretKeySpec(SECRET_KEY.getBytes(), 0, SECRET_KEY.getBytes().length, "HmacSHA512");
     }
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/security/JwtUtil.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/security/JwtUtil.java
@@ -21,17 +21,25 @@ public class JwtUtil {
     private static final String SECRET_KEY = dotenv.get("SECRET_JWT_HASH", System.getenv("SECRET_JWT_HASH"));
 
     public String generateToken(String username) {
-        return Jwts.builder()
+        long start = System.nanoTime();
+        var jwt = Jwts.builder()
                 .setSubject(username)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60))
                 .signWith(SignatureAlgorithm.HS512, generateKey())
                 .compact();
+
+        long end = System.nanoTime();
+        System.out.println("Time to generate token: " + (end - start) / 1000000 + "ms");
+        return jwt;
     }
 
     public boolean passwordsMatches(String dbHashedPassword, String saltText, String clearTextPassword) {
+        long start = System.nanoTime();
         ByteSource salt = ByteSource.Util.bytes(Hex.decode(saltText));
         String hashedPassword = hashAndSaltPassword(clearTextPassword, salt);
+        long end = System.nanoTime();
+        System.out.println("Time to hash and salt password: " + (end - start) / 1000000 + "ms");
         return hashedPassword.equals(dbHashedPassword);
     }
 
@@ -54,6 +62,10 @@ public class JwtUtil {
     }
 
     public Key generateKey() {
-        return new SecretKeySpec(SECRET_KEY.getBytes(), 0, SECRET_KEY.getBytes().length, "HmacSHA512");
+        long start = System.nanoTime();
+        var temp = new SecretKeySpec(SECRET_KEY.getBytes(), 0, SECRET_KEY.getBytes().length, "HmacSHA512");
+        long end = System.nanoTime();
+        System.out.println("Time to generate key: " + (end - start) / 1000000 + "ms");
+        return temp;
     }
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/security/JwtUtil.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/security/JwtUtil.java
@@ -54,7 +54,7 @@ public class JwtUtil {
     }
 
     private String hashAndSaltPassword(String clearTextPassword, ByteSource salt) {
-        return new Sha512Hash(clearTextPassword, salt, 2000000).toHex();
+        return new Sha512Hash(clearTextPassword, salt, 210000).toHex();
     }
 
     private ByteSource getSalt() {

--- a/gamertrack-domain/src/test/java/com/gepardec/TestFixtures.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/TestFixtures.java
@@ -5,6 +5,7 @@ import com.gepardec.model.Game;
 import com.gepardec.model.Match;
 import com.gepardec.model.Score;
 import com.gepardec.model.User;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public class TestFixtures {
     List<Game> games = new ArrayList<>();
 
     for (int i = 0; i < gameCount; i++) {
-      games.add(new Game(null, null, "TestGameTitle" + i, "TestGameRules" + i));
+      games.add(new Game(null, tokenService.generateToken(), "TestGameTitle" + i, "TestGameRules" + i));
     }
     return games;
   }

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/AuthServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/AuthServiceImplTest.java
@@ -31,21 +31,6 @@ public class AuthServiceImplTest {
 
 
     @Test
-    void ensureCreateDefaultUserIfNotExistsCreatesDefaultUser() {
-        when(authRepository.findByUsername(any())).thenReturn(Optional.empty());
-        when(authRepository.createDefaultUserIfNotExists(any())).thenReturn(true);
-
-        assertEquals(authService.createDefaultUserIfNotExists(),true);
-    }
-
-    @Test
-    void ensureCreateDefaultUserIfNotExistsWorksReturnsFalse() {
-        when(authRepository.findByUsername(any())).thenReturn(Optional.of(new AuthCredential()));
-
-        assertEquals(authService.createDefaultUserIfNotExists(),false);
-    }
-
-    @Test
     void ensureAuthenticateReturnsFalseIfCredentialsAreBlank() {
         assertEquals(authService.authenticate(new AuthCredential("admin", "")), false);
     }

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/AuthServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/AuthServiceImplTest.java
@@ -13,7 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +28,7 @@ public class AuthServiceImplTest {
     JwtUtil jwtUtil;
     @Mock
     TokenService tokenService;
+
 
     @Test
     void ensureCreateDefaultUserIfNotExistsCreatesDefaultUser() {
@@ -68,4 +69,22 @@ public class AuthServiceImplTest {
         assertEquals(authService.authenticate(new AuthCredential("admin", "CorrectPW")), true);
     }
 
+    @Test
+    void ensureIsTokenValidReturnsFalseIfTokenIsNull() {
+        assertFalse(authService.isTokenValid(null));
+    }
+
+    @Test
+    void ensureIsTokenValidReturnsFalseIfTokenIsInvalid() {
+        assertFalse(authService.isTokenValid("invalidToken.shouldNotWork.shouldBeFalse"));
+    }
+
+    @Test
+    void ensureIsTokenValidReturnsTrueIfTokenIsValid() {
+        when(jwtUtil.generateToken(any())).thenCallRealMethod();
+        when(jwtUtil.generateKey()).thenCallRealMethod();
+
+
+        assertTrue(authService.isTokenValid(jwtUtil.generateToken("AnyUser")));
+    }
 }

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/UserServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/UserServiceImplTest.java
@@ -123,7 +123,7 @@ public class UserServiceImplTest {
         User user3 = TestFixtures.user(3L);
         user3.setDeactivated(true);
 
-        when(userRepository.findAllUsers(false)).thenReturn(List.of(user1,user2));
+        when(userRepository.findAllUsersSortedByMatchCount(false)).thenReturn(List.of(user1,user2));
 
         assertEquals(2, userService.findAllUsers(false).size());
     }
@@ -134,7 +134,7 @@ public class UserServiceImplTest {
         User user3 = TestFixtures.user(3L);
         user3.setDeactivated(true);
 
-        when(userRepository.findAllUsers(true)).thenReturn(List.of(user1, user2, user3));
+        when(userRepository.findAllUsersSortedByMatchCount(true)).thenReturn(List.of(user1, user2, user3));
 
         assertEquals(3, userService.findAllUsers(true).size());
     }


### PR DESCRIPTION
Sort users by match count by default.

After getting feedback that users should be sorted by the amount of played matches, we decided that we just use the overall match amount and make it the default how users are sorted when all are returned

fixes #56 