### PR TITLE
PR: validation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ e.g
 
 or any other wildfly location
 
+## secret.env
+
+The project/application needs a secret.env file with the following variables set in order for authentication and tests to work
+
+```
+SECRET_ADMIN_NAME
+SECRET_JWT_HASH
+SECRET_DEFAULT_PW
+```
+
+For convenience the [plugin](https://plugins.jetbrains.com/plugin/7861-envfile) is recommended for reading the secret.env when tests are executed via IntelliJ 
+
 ## Build Project and deploy application
 
 - *In order for all used relative paths to work  

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/AuthResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/AuthResource.java
@@ -1,6 +1,7 @@
 package com.gepardec.rest.api;
 
 import com.gepardec.rest.model.command.AuthCredentialCommand;
+import com.gepardec.rest.model.command.ValidateTokenCommand;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -16,4 +17,8 @@ public interface AuthResource {
     @POST
     @Path("/login")
     Response login(AuthCredentialCommand authCredentialCommand);
+
+    @POST
+    @Path("/validate")
+    Response validateToken(ValidateTokenCommand token);
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
@@ -3,6 +3,7 @@ package com.gepardec.rest.impl;
 import com.gepardec.core.services.AuthService;
 import com.gepardec.rest.api.AuthResource;
 import com.gepardec.rest.model.command.AuthCredentialCommand;
+import com.gepardec.rest.model.command.ValidateTokenCommand;
 import com.gepardec.rest.model.mapper.AuthCredentialRestMapper;
 import com.gepardec.security.JwtUtil;
 import jakarta.enterprise.context.RequestScoped;
@@ -35,5 +36,12 @@ public class AuthResourceImpl implements AuthResource {
         } else {
             return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid credentials").build();
         }
+    }
+
+    @Override
+    public Response validateToken(ValidateTokenCommand tokenCmd) {
+        if (tokenCmd.token() != null && authService.isTokenValid(tokenCmd.token())) return Response.ok().build();
+
+        return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid token").build();
     }
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/model/command/ValidateTokenCommand.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/model/command/ValidateTokenCommand.java
@@ -1,0 +1,5 @@
+package com.gepardec.rest.model.command;
+
+public record ValidateTokenCommand(String token) {
+
+}

--- a/gamertrack-domain/pom.xml
+++ b/gamertrack-domain/pom.xml
@@ -71,6 +71,35 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>read-project-properties</goal>
+            </goals>
+            <configuration>
+              <quiet>true</quiet>
+              <files>
+              <file>${project.parent.basedir}/secret.env</file>
+              </files>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+        <configuration>
+          <environmentVariables>
+            <SECRET_JWT_HASH>${SECRET_JWT_HASH}</SECRET_JWT_HASH>
+          </environmentVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/AuthService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/AuthService.java
@@ -5,4 +5,5 @@ import com.gepardec.model.AuthCredential;
 public interface AuthService {
     boolean authenticate(AuthCredential credential);
     boolean createDefaultUserIfNotExists();
+    boolean isTokenValid(String token);
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/AuthServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/AuthServiceImpl.java
@@ -6,6 +6,8 @@ import com.gepardec.core.services.TokenService;
 import com.gepardec.model.AuthCredential;
 import com.gepardec.security.JwtUtil;
 import io.github.cdimascio.dotenv.Dotenv;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -77,5 +79,17 @@ public class AuthServiceImpl implements AuthService {
             }
             return false; //user was not created
         }
+    }
+
+    @Override
+    public boolean isTokenValid(String token) {
+        boolean isValid = false;
+        try {
+            Jwts.parser().setSigningKey(jwtUtil.generateKey()).build().parseClaimsJws(token);
+            isValid = true;
+        } catch (JwtException e) {
+            log.error("Token validation failed {}", e.getMessage());
+        }
+        return isValid;
     }
 }

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/AuthServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/AuthServiceImplTest.java
@@ -13,7 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +28,7 @@ public class AuthServiceImplTest {
     JwtUtil jwtUtil;
     @Mock
     TokenService tokenService;
+
 
     @Test
     void ensureCreateDefaultUserIfNotExistsCreatesDefaultUser() {
@@ -68,4 +69,22 @@ public class AuthServiceImplTest {
         assertEquals(authService.authenticate(new AuthCredential("admin", "CorrectPW")), true);
     }
 
+    @Test
+    void ensureIsTokenValidReturnsFalseIfTokenIsNull() {
+        assertFalse(authService.isTokenValid(null));
+    }
+
+    @Test
+    void ensureIsTokenValidReturnsFalseIfTokenIsInvalid() {
+        assertFalse(authService.isTokenValid("invalidToken.shouldNotWork.shouldBeFalse"));
+    }
+
+    @Test
+    void ensureIsTokenValidReturnsTrueIfTokenIsValid() {
+        when(jwtUtil.generateToken(any())).thenCallRealMethod();
+        when(jwtUtil.generateKey()).thenCallRealMethod();
+
+
+        assertTrue(authService.isTokenValid(jwtUtil.generateToken("AnyUser")));
+    }
 }


### PR DESCRIPTION
add validation endpoint that the frontend can use to validate the current set jwt token and decide whether

- the user is logged in
- the user is authorised to see certain elements/pages based on whether aunthenticated

add tests for new endpoint
add properties-maven-plugin to read secret.env file and let maven-surefire-plugin set env variables based on found properties in file
edit README.md with plugin recommendation for env files and that secrets.env is required

fixes #58 