### PR TITLE
fix: LAKWYC-6 reject match when a participant has no score instead of NPE

### DIFF
--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/MatchResourceImplIT.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/MatchResourceImplIT.java
@@ -1,14 +1,17 @@
 package com.gepardec.rest.impl;
 
+import com.gepardec.core.services.ScoreService;
 import com.gepardec.model.Game;
 import com.gepardec.model.User;
 import com.gepardec.rest.model.command.*;
 import com.gepardec.rest.model.dto.GameRestDto;
 import com.gepardec.rest.model.dto.MatchRestDto;
+import com.gepardec.rest.model.dto.ScoreRestDto;
 import com.gepardec.rest.model.dto.UserRestDto;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response.Status;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterAll;
@@ -39,6 +42,9 @@ public class MatchResourceImplIT {
     String SECRET_DEFAULT_PW;
     @ConfigProperty(name = "secret.admin.name")
     String SECRET_ADMIN_NAME;
+
+    @Inject
+    ScoreService scoreService;
 
 
 
@@ -370,6 +376,82 @@ public class MatchResourceImplIT {
     }
 
     @Test
+    void ensureCreateMatchForUserWithoutScoreReturns400BadRequestAndPersistsNothing() {
+        GameRestDto createdGame = createGame();
+        UserRestDto userWithoutScore = createUser();
+        UserRestDto userWithScore = createUser();
+
+        // Simulate a user without a score for the game (e.g. after deactivation removed
+        // the default scores) by deleting the user's default score directly.
+        scoreService.filterScores(null, null, userWithoutScore.token(), createdGame.token(), true)
+                .forEach(score -> scoreService.deleteScore(score.getToken()));
+
+        CreateMatchCommand createMatchCommand = new CreateMatchCommand(
+                new Game(null, createdGame.token(), createdGame.name(), createdGame.rules()),
+                List.of(new User(null, userWithoutScore.firstname(), userWithoutScore.lastname(),
+                                userWithoutScore.deactivated(), userWithoutScore.token()),
+                        new User(null, userWithScore.firstname(), userWithScore.lastname(),
+                                userWithScore.deactivated(), userWithScore.token())));
+
+        with()
+                .headers(
+                        "Authorization",
+                        "Bearer " + bearerToken,
+                        "Content-Type",
+                        ContentType.JSON,
+                        "Accept",
+                        ContentType.JSON)
+                .body(createMatchCommand)
+                .contentType("application/json")
+                .post(MATCH_PATH)
+                .then()
+                .statusCode(Status.BAD_REQUEST.getStatusCode());
+
+        // no match was persisted
+        var foundMatches = given()
+                .queryParam("gameToken", createdGame.token())
+                .when()
+                .get(MATCH_PATH)
+                .then()
+                .statusCode(Status.OK.getStatusCode())
+                .extract()
+                .jsonPath()
+                .getList("", MatchRestDto.class);
+
+        assertTrue(foundMatches.isEmpty());
+
+        // and no rating was updated: the other user's score is still the default
+        var foundScores = given()
+                .queryParam("game", createdGame.token())
+                .queryParam("user", userWithScore.token())
+                .when()
+                .get("/scores")
+                .then()
+                .statusCode(Status.OK.getStatusCode())
+                .extract()
+                .jsonPath()
+                .getList("", ScoreRestDto.class);
+
+        assertEquals(1, foundScores.size());
+        assertEquals(1500.0, foundScores.getFirst().score());
+    }
+
+    @Test
+    void ensureCreateMatchWorksForBothUserAndGameCreationOrders() {
+        // game created before its users
+        GameRestDto gameCreatedFirst = createGame();
+        MatchRestDto matchForGameCreatedFirst = createMatch(createUser(), createUser(), gameCreatedFirst);
+        assertEquals(gameCreatedFirst.token(), matchForGameCreatedFirst.game().token());
+
+        // users created before the game
+        UserRestDto userCreatedFirst1 = createUser();
+        UserRestDto userCreatedFirst2 = createUser();
+        GameRestDto gameCreatedLast = createGame("game created after users");
+        MatchRestDto matchForGameCreatedLast = createMatch(userCreatedFirst1, userCreatedFirst2, gameCreatedLast);
+        assertEquals(gameCreatedLast.token(), matchForGameCreatedLast.game().token());
+    }
+
+    @Test
     void ensureUpdateMatchForExistingMatchReturns200OkWithUpdatedMatch() {
         MatchRestDto existingMatch = createMatch();
         UserRestDto userRestDto = createUser();
@@ -493,6 +575,10 @@ public class MatchResourceImplIT {
         return userRestDto;
     }
     public GameRestDto createGame() {
+        return createGame("default Game");
+    }
+
+    public GameRestDto createGame(String name) {
         GameRestDto gameRestDto = with()
                 .headers(
                         "Authorization",
@@ -501,7 +587,7 @@ public class MatchResourceImplIT {
                         ContentType.JSON,
                         "Accept",
                         ContentType.JSON)
-                .body(new CreateGameCommand("default Game", "no rules"))
+                .body(new CreateGameCommand(name, "no rules"))
                 .contentType("application/json")
                 .accept("application/json")
                 .when()

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/MatchService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/MatchService.java
@@ -8,6 +8,17 @@ import java.util.Optional;
 
 public interface MatchService {
 
+    /**
+     * Saves a match and updates the Elo ratings of all participants in one transaction.
+     * <p>
+     * Every participant must already have a score for the match's game. If any
+     * participant has no score (e.g. because their default scores were removed on
+     * deactivation), the match is rejected and nothing is persisted — a match is
+     * never saved without its rating updates and vice versa.
+     *
+     * @return the saved match, or {@link Optional#empty()} if the match is invalid
+     * or a participant has no score for the game
+     */
     Optional<Match> saveMatch(Match match);
 
     List<Match> findAllMatches();

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/MatchServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/MatchServiceImpl.java
@@ -87,18 +87,29 @@ public class MatchServiceImpl implements MatchService {
                 match.setGame(foundGame.get());
                 match.setUsers(foundUsers);
 
+                // Collect the participants' scores BEFORE persisting the match, so a match is
+                // never saved without its rating updates being applied. A participant without a
+                // score for the game (e.g. after deactivation removed their default scores)
+                // rejects the whole match instead of failing with an NPE halfway through.
+                List<Score> scoreList = new ArrayList<>();
+
+                for (User user : match.getUsers()) {
+                    List<Score> filteredScores = scoreService.filterScores(null, null, user.getToken(), match.getGame().getToken(), true);
+                    if (filteredScores.isEmpty()) {
+                        logger.error(
+                                "Match was not saved: no score exists for user %s %s (token: %s) and game %s (token: %s)".formatted(
+                                        user.getFirstname(), user.getLastname(), user.getToken(),
+                                        match.getGame().getName(), match.getGame().getToken()));
+                        return Optional.empty();
+                    }
+                    scoreList.add(filteredScores.getFirst());
+                }
+
                 logger.info(
                         "Saving match containing GameID: %s and UserIDs: %s".formatted(
                                 match.getGame().getId(), match.getUsers().stream().map(User::getId).toList()));
 
                 Optional<Match> savedMatch = matchRepository.saveMatch(match);
-
-                List<Score> scoreList = new ArrayList<>();
-
-                for (User user : match.getUsers()) {
-                    List<Score> filteredScores = scoreService.filterScores(null, null, user.getToken(), match.getGame().getToken(), true);
-                    scoreList.add(filteredScores.isEmpty() ? null : filteredScores.getFirst());
-                }
 
                 List<Score> updatedScores = eloService.updateElo(match.getGame(), scoreList, match.getUsers());
                 for (Score score : updatedScores) {

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/MatchServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/MatchServiceImplTest.java
@@ -8,6 +8,7 @@ import com.gepardec.core.repository.UserRepository;
 import com.gepardec.core.services.EloService;
 import com.gepardec.core.services.TokenService;
 import com.gepardec.model.Match;
+import com.gepardec.model.Score;
 import jakarta.data.page.PageRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,10 +68,40 @@ class MatchServiceImplTest {
                 invocation -> match.getUsers().stream()
                         .filter(user -> user.getToken().equals(invocation.getArgument(0)))
                         .findFirst());
+        when(scoreService.filterScores(any(), any(), anyString(), anyString(), any())).thenAnswer(
+                invocation -> match.getUsers().stream()
+                        .filter(user -> user.getToken().equals(invocation.getArgument(2)))
+                        .map(user -> new Score(user.getId(), user, match.getGame(), 1500L, user.getToken(), true))
+                        .toList());
 
 
         assertEquals(matchService.saveMatch(match).get().getId(),
                 match().getId());
+        verify(scoreService, times(match.getUsers().size())).filterScores(any(), any(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void ensureSavingMatchWithUserMissingScoreReturnsEmptyOptionalWithoutPersistingMatch() {
+        //Given
+        Match match = match();
+
+        when(tokenService.generateToken()).thenReturn(match.getToken());
+        when(gameRepository.findGameByToken(anyString())).thenReturn(
+                Optional.of(match.getGame()));
+        when(userRepository.findUserByToken(anyString())).thenAnswer(
+                invocation -> match.getUsers().stream()
+                        .filter(user -> user.getToken().equals(invocation.getArgument(0)))
+                        .findFirst());
+        when(scoreService.filterScores(any(), any(), anyString(), anyString(), any())).thenReturn(List.of());
+
+        //When
+        var savedMatch = matchService.saveMatch(match);
+
+        //Then
+        assertEquals(Optional.empty(), savedMatch);
+        verify(matchRepository, never()).saveMatch(any());
+        verify(eloService, never()).updateElo(any(), any(), any());
+        verify(scoreService, never()).updateScore(any());
     }
 
     @Test


### PR DESCRIPTION
## LAKWYC-6 — Missing participant score caused NPE after match was persisted

**Root cause:** `MatchServiceImpl.saveMatch` persisted the match first, then inserted `null` into the score list for any participant without a score for the game; the Elo service dereferenced it → NPE/500 with the match already saved but no ratings applied.

**Fix (chosen behavior: reject, not auto-create):**
- Participant scores are validated **before** the match is persisted — a missing score rejects the match (400 Bad Request) and nothing is saved, so match persistence and rating updates can no longer come apart.
- The error log names the concrete user (name + token) and game (name + token).
- Auto-creating scores was deliberately rejected: user deactivation removes default scores on purpose; recreating them silently would resurrect discarded state. Documented in `MatchService.saveMatch` Javadoc.

**Tests:**
- Unit: rejection path returns empty Optional and `saveMatch`/`updateElo`/`updateScore` are verified never called; normal save still works.
- Integration: missing-score match → 400 with no match persisted and the other participant's rating untouched at 1500; regression that match creation works for both user-first and game-first creation orders.

**Verification:** `MatchServiceImplTest` 20/20 green, full `mvnw verify -Prun-integrationtests` 51/51 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)