### PR TITLE
feat: LAKWYC-4 store explicit match outcome (placement per participant, draws supported)

### DIFF
--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/MatchResourceImplIT.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/MatchResourceImplIT.java
@@ -9,6 +9,7 @@ import com.gepardec.rest.model.dto.UserRestDto;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
 import jakarta.ws.rs.core.Response.Status;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterAll;
@@ -18,7 +19,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static io.restassured.RestAssured.*;
 import static java.lang.Math.ceil;
@@ -319,7 +322,8 @@ public class MatchResourceImplIT {
                 List.of(new User(userRestDto1.id(), userRestDto1.firstname(), userRestDto1.lastname(),
                                 userRestDto1.deactivated(), userRestDto1.token()),
                         new User(userRestDto2.id(), userRestDto2.firstname(), userRestDto2.lastname(),
-                                userRestDto2.deactivated(), userRestDto2.token())));
+                                userRestDto2.deactivated(), userRestDto2.token())),
+                Map.of(userRestDto1.token(), 1, userRestDto2.token(), 2));
 
         MatchRestDto createdMatch =
                 with()
@@ -342,6 +346,7 @@ public class MatchResourceImplIT {
 
         assertEquals(createdMatch.game().token(), createMatchCommand.game().getToken());
         assertTrue(createdMatch.users().containsAll(createMatchCommand.users().stream().map(UserRestDto::new).toList()));
+        assertEquals(createMatchCommand.outcome(), createdMatch.outcome());
         usesMatchTokens.add(createdMatch.token());
     }
 
@@ -352,7 +357,8 @@ public class MatchResourceImplIT {
         CreateMatchCommand createMatchCommand = new CreateMatchCommand(
                 new Game(null, null, "anything", "should fail"),
                 List.of(new User(null, userRestDto.firstname(), userRestDto.lastname(),
-                        userRestDto.deactivated(), userRestDto.token())));
+                        userRestDto.deactivated(), userRestDto.token())),
+                Map.of(userRestDto.token(), 1));
 
         with()
                 .headers(
@@ -383,7 +389,8 @@ public class MatchResourceImplIT {
                         new User(null, userRestDto.firstname(), userRestDto.lastname(),
                                 userRestDto.deactivated(), userRestDto.token()),
                         new User(null, userRestDto.firstname(), userRestDto.lastname(),
-                                userRestDto.deactivated(), userRestDto.token())));
+                                userRestDto.deactivated(), userRestDto.token())),
+                Map.of(existingMatch.users().getFirst().token(), 1, userRestDto.token(), 2));
 
         var updatedMatch =
                 given()
@@ -469,6 +476,227 @@ public class MatchResourceImplIT {
                 .statusCode(Status.NOT_FOUND.getStatusCode());
     }
 
+    @Test
+    void ensureCreateMatchWithFourPlayersStoresAllPlacements() {
+        GameRestDto createdGame = createGame();
+        List<UserRestDto> createdUsers = List.of(createUser(), createUser(), createUser(), createUser());
+
+        Map<String, Integer> outcome = new HashMap<>();
+        for (int i = 0; i < createdUsers.size(); i++) {
+            outcome.put(createdUsers.get(i).token(), i + 1);
+        }
+
+        MatchRestDto createdMatch = postMatch(createMatchCommand(createdGame, createdUsers, outcome))
+                .statusCode(Status.CREATED.getStatusCode())
+                .extract()
+                .as(MatchRestDto.class);
+        usesMatchTokens.add(createdMatch.token());
+
+        assertEquals(outcome, createdMatch.outcome());
+    }
+
+    @Test
+    void ensureCreateMatchWithDrawReturnsDrawOutcomeAndKeepsEqualRatingsUnchanged() {
+        GameRestDto createdGame = createGame();
+        UserRestDto createdUser1 = createUser();
+        UserRestDto createdUser2 = createUser();
+
+        MatchRestDto createdMatch = createMatch(createdUser1, createdUser2, createdGame,
+                Map.of(createdUser1.token(), 1, createdUser2.token(), 1));
+
+        assertEquals(Map.of(createdUser1.token(), 1, createdUser2.token(), 1), createdMatch.outcome());
+
+        //both users started with the same default rating, so a draw must not change it
+        with()
+                .contentType("application/json")
+                .request("GET", "/scores/?game=" + createdGame.token())
+                .then()
+                .statusCode(Status.OK.getStatusCode())
+                .body("score", everyItem(equalTo(1500.0f)));
+    }
+
+    @Test
+    void ensureCreateMatchWithPlacementsDifferingFromUserOrderFollowsThePlacements() {
+        GameRestDto createdGame = createGame();
+        UserRestDto createdUser1 = createUser();
+        UserRestDto createdUser2 = createUser();
+
+        //the first user in the list is NOT the winner - the placements decide
+        MatchRestDto createdMatch = createMatch(createdUser1, createdUser2, createdGame,
+                Map.of(createdUser1.token(), 2, createdUser2.token(), 1));
+
+        assertEquals(2, createdMatch.outcome().get(createdUser1.token()));
+        assertEquals(1, createdMatch.outcome().get(createdUser2.token()));
+
+        var foundScores = with()
+                .contentType("application/json")
+                .request("GET", "/scores/?game=" + createdGame.token())
+                .then()
+                .statusCode(Status.OK.getStatusCode())
+                .extract()
+                .jsonPath();
+
+        assertEquals(1516.0f, foundScores.getFloat(
+                "find { it.user.token == '%s' }.score".formatted(createdUser2.token())));
+        assertEquals(1484.0f, foundScores.getFloat(
+                "find { it.user.token == '%s' }.score".formatted(createdUser1.token())));
+    }
+
+    @Test
+    void ensureGetMatchByTokenReturnsExactlyTheEnteredPlacements() {
+        GameRestDto createdGame = createGame();
+        UserRestDto createdUser1 = createUser();
+        UserRestDto createdUser2 = createUser();
+
+        MatchRestDto createdMatch = createMatch(createdUser1, createdUser2, createdGame,
+                Map.of(createdUser1.token(), 2, createdUser2.token(), 1));
+
+        MatchRestDto foundMatch = given()
+                .pathParam("token", createdMatch.token())
+                .when()
+                .get("%s/{token}".formatted(MATCH_PATH))
+                .then()
+                .statusCode(Status.OK.getStatusCode())
+                .extract()
+                .as(MatchRestDto.class);
+
+        assertEquals(Map.of(createdUser1.token(), 2, createdUser2.token(), 1), foundMatch.outcome());
+    }
+
+    @Test
+    void ensureCreateMatchWithInvalidOutcomeReturns400BadRequest() {
+        GameRestDto createdGame = createGame();
+        UserRestDto createdUser1 = createUser();
+        UserRestDto createdUser2 = createUser();
+        List<UserRestDto> createdUsers = List.of(createdUser1, createdUser2);
+
+        //no outcome at all
+        postMatch(createMatchCommand(createdGame, createdUsers, null))
+                .statusCode(Status.BAD_REQUEST.getStatusCode());
+
+        //participant without placement
+        postMatch(createMatchCommand(createdGame, createdUsers,
+                Map.of(createdUser1.token(), 1)))
+                .statusCode(Status.BAD_REQUEST.getStatusCode());
+
+        //placement for a user that is not part of the match
+        postMatch(createMatchCommand(createdGame, createdUsers,
+                Map.of(createdUser1.token(), 1, "notAParticipant", 2)))
+                .statusCode(Status.BAD_REQUEST.getStatusCode());
+
+        //gap that is not caused by a tie
+        postMatch(createMatchCommand(createdGame, createdUsers,
+                Map.of(createdUser1.token(), 1, createdUser2.token(), 3)))
+                .statusCode(Status.BAD_REQUEST.getStatusCode());
+
+        //placement below 1
+        postMatch(createMatchCommand(createdGame, createdUsers,
+                Map.of(createdUser1.token(), 0, createdUser2.token(), 1)))
+                .statusCode(Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test
+    void ensureCreateMatchWithTieNotSkippingFollowingPlacementReturns400BadRequest() {
+        GameRestDto createdGame = createGame();
+        UserRestDto createdUser1 = createUser();
+        UserRestDto createdUser2 = createUser();
+        UserRestDto createdUser3 = createUser();
+        List<UserRestDto> createdUsers = List.of(createdUser1, createdUser2, createdUser3);
+
+        //two players share first place, so the next placement has to be 3 - not 2
+        postMatch(createMatchCommand(createdGame, createdUsers,
+                Map.of(createdUser1.token(), 1, createdUser2.token(), 1, createdUser3.token(), 2)))
+                .statusCode(Status.BAD_REQUEST.getStatusCode());
+
+        MatchRestDto createdMatch = postMatch(createMatchCommand(createdGame, createdUsers,
+                Map.of(createdUser1.token(), 1, createdUser2.token(), 1, createdUser3.token(), 3)))
+                .statusCode(Status.CREATED.getStatusCode())
+                .extract()
+                .as(MatchRestDto.class);
+        usesMatchTokens.add(createdMatch.token());
+
+        assertEquals(Map.of(createdUser1.token(), 1, createdUser2.token(), 1, createdUser3.token(), 3),
+                createdMatch.outcome());
+    }
+
+    @Test
+    void ensureUpdateMatchCorrectingTheOutcomeStoresTheNewOutcome() {
+        GameRestDto createdGame = createGame();
+        UserRestDto createdUser1 = createUser();
+        UserRestDto createdUser2 = createUser();
+
+        MatchRestDto existingMatch = createMatch(createdUser1, createdUser2, createdGame,
+                Map.of(createdUser1.token(), 1, createdUser2.token(), 2));
+
+        //the wrong winner was entered - swap the placements
+        UpdateMatchCommand matchToUpdate = new UpdateMatchCommand(
+                new Game(null, createdGame.token(), createdGame.name(), createdGame.rules()),
+                List.of(new User(null, createdUser1.firstname(), createdUser1.lastname(),
+                                createdUser1.deactivated(), createdUser1.token()),
+                        new User(null, createdUser2.firstname(), createdUser2.lastname(),
+                                createdUser2.deactivated(), createdUser2.token())),
+                Map.of(createdUser1.token(), 2, createdUser2.token(), 1));
+
+        given()
+                .pathParam("token", existingMatch.token())
+                .contentType("application/json")
+                .headers(
+                        "Authorization",
+                        "Bearer " + bearerToken,
+                        "Content-Type",
+                        ContentType.JSON,
+                        "Accept",
+                        ContentType.JSON)
+                .body(matchToUpdate)
+                .put("%s/{token}".formatted(MATCH_PATH))
+                .then()
+                .statusCode(Status.OK.getStatusCode());
+
+        MatchRestDto foundMatch = given()
+                .pathParam("token", existingMatch.token())
+                .when()
+                .get("%s/{token}".formatted(MATCH_PATH))
+                .then()
+                .statusCode(Status.OK.getStatusCode())
+                .extract()
+                .as(MatchRestDto.class);
+
+        assertEquals(matchToUpdate.outcome(), foundMatch.outcome());
+    }
+
+    @Test
+    void ensureUpdateMatchWithInvalidOutcomeReturns400BadRequest() {
+        GameRestDto createdGame = createGame();
+        UserRestDto createdUser1 = createUser();
+        UserRestDto createdUser2 = createUser();
+
+        MatchRestDto existingMatch = createMatch(createdUser1, createdUser2, createdGame,
+                Map.of(createdUser1.token(), 1, createdUser2.token(), 2));
+
+        UpdateMatchCommand matchToUpdate = new UpdateMatchCommand(
+                new Game(null, createdGame.token(), createdGame.name(), createdGame.rules()),
+                List.of(new User(null, createdUser1.firstname(), createdUser1.lastname(),
+                                createdUser1.deactivated(), createdUser1.token()),
+                        new User(null, createdUser2.firstname(), createdUser2.lastname(),
+                                createdUser2.deactivated(), createdUser2.token())),
+                Map.of(createdUser1.token(), 1, createdUser2.token(), 3));
+
+        given()
+                .pathParam("token", existingMatch.token())
+                .contentType("application/json")
+                .headers(
+                        "Authorization",
+                        "Bearer " + bearerToken,
+                        "Content-Type",
+                        ContentType.JSON,
+                        "Accept",
+                        ContentType.JSON)
+                .body(matchToUpdate)
+                .put("%s/{token}".formatted(MATCH_PATH))
+                .then()
+                .statusCode(Status.BAD_REQUEST.getStatusCode());
+    }
+
     //-------------------HELPER METHODS -------------------------//
     public UserRestDto createUser() {
         UserRestDto userRestDto =
@@ -520,13 +748,45 @@ public class MatchResourceImplIT {
         return createMatch(createUser(),createUser(), createGame());
     }
 
+    public CreateMatchCommand createMatchCommand(GameRestDto gameRestDto, List<UserRestDto> userRestDtos,
+                                                 Map<String, Integer> outcome) {
+        return new CreateMatchCommand(
+                new Game(null, gameRestDto.token(), gameRestDto.name(), gameRestDto.rules()),
+                userRestDtos.stream()
+                        .map(u -> new User(null, u.firstname(), u.lastname(), u.deactivated(), u.token()))
+                        .toList(),
+                outcome);
+    }
+
+    public ValidatableResponse postMatch(CreateMatchCommand createMatchCommand) {
+        return with()
+                .headers(
+                        "Authorization",
+                        "Bearer " + bearerToken,
+                        "Content-Type",
+                        ContentType.JSON,
+                        "Accept",
+                        ContentType.JSON)
+                .body(createMatchCommand)
+                .contentType("application/json")
+                .post(MATCH_PATH)
+                .then();
+    }
+
     public MatchRestDto createMatch(UserRestDto userRestDto1, UserRestDto userRestDto2, GameRestDto gameRestDto) {
+        return createMatch(userRestDto1, userRestDto2, gameRestDto,
+                Map.of(userRestDto1.token(), 1, userRestDto2.token(), 2));
+    }
+
+    public MatchRestDto createMatch(UserRestDto userRestDto1, UserRestDto userRestDto2, GameRestDto gameRestDto,
+                                    Map<String, Integer> outcome) {
         CreateMatchCommand createMatchCommand = new CreateMatchCommand(
                 new Game(null, gameRestDto.token(), gameRestDto.name(), gameRestDto.rules()),
                 List.of(new User(null, userRestDto1.firstname(), userRestDto1.lastname(),
                                 userRestDto1.deactivated(), userRestDto1.token()),
                         new User(null, userRestDto2.firstname(), userRestDto2.lastname(),
-                                userRestDto2.deactivated(), userRestDto2.token())));
+                                userRestDto2.deactivated(), userRestDto2.token())),
+                outcome);
 
         MatchRestDto createdMatch =
                 with()

--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/RestTestFixtures.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/RestTestFixtures.java
@@ -8,8 +8,12 @@ import com.gepardec.rest.model.dto.GameRestDto;
 import com.gepardec.rest.model.dto.MatchRestDto;
 import com.gepardec.rest.model.dto.UserRestDto;
 
+import com.gepardec.TestFixtures;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.gepardec.TestFixtures.user;
 
@@ -28,11 +32,13 @@ public class RestTestFixtures {
   }
 
   public static UpdateMatchCommand updateMatchCommand() {
-    return new UpdateMatchCommand(game(), users(5));
+    List<User> users = users(5);
+    return new UpdateMatchCommand(game(), users, TestFixtures.outcome(users));
   }
 
   public static CreateMatchCommand createMatchCommand() {
-    return new CreateMatchCommand(game(), users(5));
+    List<User> users = users(5);
+    return new CreateMatchCommand(game(), users, TestFixtures.outcome(users));
   }
 
   public static CreateGameCommand createGameCommand() {
@@ -42,7 +48,11 @@ public class RestTestFixtures {
 
   public static MatchRestDto matchRestDto(String token, GameRestDto gameRestDto,
       List<UserRestDto> userRestDtos) {
-    return new MatchRestDto(token, "2025-01-01 12:12:12","2025-01-01 12:12:12", gameRestDto, userRestDtos);
+    Map<String, Integer> outcome = new HashMap<>();
+    for (int i = 0; i < userRestDtos.size(); i++) {
+      outcome.put(userRestDtos.get(i).token(), i + 1);
+    }
+    return new MatchRestDto(token, "2025-01-01 12:12:12","2025-01-01 12:12:12", gameRestDto, userRestDtos, outcome);
   }
 
   public static Game game() {

--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/service/EloServiceImplIT.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/service/EloServiceImplIT.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static io.restassured.RestAssured.enableLoggingOfRequestAndResponseIfValidationFails;
 import static io.restassured.RestAssured.with;
@@ -166,12 +167,14 @@ public class EloServiceImplIT {
                 new Game(null, gameToken1, "4Gewinnt", "Nicht schummeln"),
                 List.of(new User(0L, "Max","Muster",
                        false, userToken1),new User(0L, "Jakob","Mayer",
-                        false, userToken2)));
+                        false, userToken2)),
+                Map.of(userToken1, 1, userToken2, 2));
 
         CreateMatchCommand createMatchCommandUser2Wins = new CreateMatchCommand(
                 new Game(null, gameToken1, "4Gewinnt", "Nicht schummeln"),
                 List.of(new User(0L, "Jakob","Mayer",false, userToken2)
-                        , new User(0L, "Max","Muster",false, userToken1)));
+                        , new User(0L, "Max","Muster",false, userToken1)),
+                Map.of(userToken2, 1, userToken1, 2));
 
         with()
                 .headers(

--- a/gamertrack-application/src/main/java/com/gepardec/rest/api/MatchResource.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/api/MatchResource.java
@@ -44,7 +44,7 @@ public interface MatchResource {
   Response getMatchByToken(@PathParam("token") String token);
 
 
-  @Operation(summary = "Creates a match", description = "Match must be valid")
+  @Operation(summary = "Creates a match", description = "Match must be valid and carry a complete outcome: every participating user needs a placement (1-based, tied users share a placement, the following placement skips the tied users). The Elo rating changes are derived from the outcome.")
   @RequestBody(content = @Content(schema = @Schema(implementation = CreateMatchCommand.class)))
   @ApiResponses(value = {
       @ApiResponse(responseCode = "201", description = "Created", content = {
@@ -58,7 +58,7 @@ public interface MatchResource {
   Response createMatch(CreateMatchCommand matchCmd);
 
 
-  @Operation(summary = "Updates a match", description = "Match must be valid and exist, specified user and game ids that make up the match have to exist")
+  @Operation(summary = "Updates a match", description = "Match must be valid and exist, specified user and game ids that make up the match have to exist. The outcome must be complete for the specified users and follows the same validation as on create.")
   @RequestBody(content = @Content(schema = @Schema(implementation = UpdateMatchCommand.class)))
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "Match has been updated", content = {

--- a/gamertrack-application/src/main/java/com/gepardec/rest/model/command/CreateMatchCommand.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/model/command/CreateMatchCommand.java
@@ -2,9 +2,15 @@ package com.gepardec.rest.model.command;
 
 import com.gepardec.model.Game;
 import com.gepardec.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Map;
 
-public record CreateMatchCommand(@NotNull Game game, @NotNull List<User> users) {
+public record CreateMatchCommand(@NotNull Game game, @NotNull List<User> users,
+                                 @NotNull
+                                 @Schema(description = "Placement per participating user token (1-based). Tied users share a placement, the following placement skips the tied users (e.g. 1,1,3).",
+                                     example = "{\"userToken1\": 1, \"userToken2\": 2}")
+                                 Map<String, Integer> outcome) {
 
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/model/command/UpdateMatchCommand.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/model/command/UpdateMatchCommand.java
@@ -2,9 +2,14 @@ package com.gepardec.rest.model.command;
 
 import com.gepardec.model.Game;
 import com.gepardec.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
+import java.util.Map;
 
-public record UpdateMatchCommand(Game game, List<User> users) {
+public record UpdateMatchCommand(Game game, List<User> users,
+                                 @Schema(description = "Placement per participating user token (1-based). Tied users share a placement, the following placement skips the tied users (e.g. 1,1,3).",
+                                     example = "{\"userToken1\": 1, \"userToken2\": 2}")
+                                 Map<String, Integer> outcome) {
 
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/model/dto/MatchRestDto.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/model/dto/MatchRestDto.java
@@ -1,16 +1,21 @@
 package com.gepardec.rest.model.dto;
 
 import com.gepardec.model.Match;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public record MatchRestDto(@NotBlank String token, @NotNull String createdOn, String updatedOn, @NotNull GameRestDto game,
-                           @NotNull List<UserRestDto> users) {
+                           @NotNull List<UserRestDto> users,
+                           @Schema(description = "Placement per participating user token (1-based, tied users share a placement). Empty for matches created before outcomes were recorded.")
+                           Map<String, Integer> outcome) {
 
     public MatchRestDto(Match match) {
         this(match.getToken(),
@@ -21,7 +26,8 @@ public record MatchRestDto(@NotBlank String token, @NotNull String createdOn, St
                         match.getUsers().stream()
                                 .map(UserRestDto::new)
                                 .toList()
-                ));
+                ),
+                new HashMap<>(match.getOutcome() == null ? Map.of() : match.getOutcome()));
     }
 
     @Override
@@ -31,12 +37,13 @@ public record MatchRestDto(@NotBlank String token, @NotNull String createdOn, St
         }
         MatchRestDto that = (MatchRestDto) o;
         return Objects.equals(game, that.game) && Objects.equals(token, that.token)
-                && Objects.equals(users, that.users) && Objects.equals(createdOn, that.createdOn) && Objects.equals(updatedOn, that.updatedOn);
+                && Objects.equals(users, that.users) && Objects.equals(createdOn, that.createdOn) && Objects.equals(updatedOn, that.updatedOn)
+                && Objects.equals(outcome, that.outcome);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(token, game, users,createdOn, updatedOn);
+        return Objects.hash(token, game, users, createdOn, updatedOn, outcome);
     }
 
     @Override
@@ -45,6 +52,7 @@ public record MatchRestDto(@NotBlank String token, @NotNull String createdOn, St
                 "token='" + token + '\'' +
                 ", game=" + game +
                 ", users=" + users +
+                ", outcome=" + outcome +
                 '}';
     }
 }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/model/mapper/MatchRestMapper.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/model/mapper/MatchRestMapper.java
@@ -11,10 +11,11 @@ public class MatchRestMapper {
   public Match updateMatchCommandtoMatch(Long id, String token,
       UpdateMatchCommand updateMatchCommand) {
     return new Match(id, token, updateMatchCommand.game(),
-        updateMatchCommand.users());
+        updateMatchCommand.users(), updateMatchCommand.outcome());
   }
 
   public Match createMatchCommandtoMatch(CreateMatchCommand createMatchCommand) {
-    return new Match(null, null, createMatchCommand.game(), createMatchCommand.users());
+    return new Match(null, null, createMatchCommand.game(), createMatchCommand.users(),
+        createMatchCommand.outcome());
   }
 }

--- a/gamertrack-application/src/test/java/com/gepardec/RestTestFixtures.java
+++ b/gamertrack-application/src/test/java/com/gepardec/RestTestFixtures.java
@@ -9,7 +9,11 @@ import com.gepardec.rest.model.dto.MatchRestDto;
 import com.gepardec.rest.model.dto.UserRestDto;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import com.gepardec.TestFixtures;
 
 import static com.gepardec.TestFixtures.user;
 
@@ -34,11 +38,13 @@ public class RestTestFixtures {
   }
 
   public static UpdateMatchCommand updateMatchCommand() {
-    return new UpdateMatchCommand(game(), users(5));
+    List<User> users = users(5);
+    return new UpdateMatchCommand(game(), users, TestFixtures.outcome(users));
   }
 
   public static CreateMatchCommand createMatchCommand() {
-    return new CreateMatchCommand(game(), users(5));
+    List<User> users = users(5);
+    return new CreateMatchCommand(game(), users, TestFixtures.outcome(users));
   }
 
   public static CreateGameCommand createGameCommand() {
@@ -47,7 +53,11 @@ public class RestTestFixtures {
 
 
   public static MatchRestDto matchRestDto(String token, GameRestDto gameRestDto, List<UserRestDto> userRestDtos) {
-      return new MatchRestDto(token, "2025-01-01 12:12:12","2025-01-01 12:12:12", gameRestDto, userRestDtos);
+      Map<String, Integer> outcome = new HashMap<>();
+      for (int i = 0; i < userRestDtos.size(); i++) {
+          outcome.put(userRestDtos.get(i).token(), i + 1);
+      }
+      return new MatchRestDto(token, "2025-01-01 12:12:12","2025-01-01 12:12:12", gameRestDto, userRestDtos, outcome);
   }
 
   public static Game game() {

--- a/gamertrack-application/src/test/java/com/gepardec/rest/model/mapper/MatchRestMapperTest.java
+++ b/gamertrack-application/src/test/java/com/gepardec/rest/model/mapper/MatchRestMapperTest.java
@@ -34,6 +34,9 @@ public class MatchRestMapperTest {
     assertTrue(mappedMatch.getUsers().stream().map(User::getId).toList()
         .containsAll(
             RestTestFixtures.createMatchCommand().users().stream().map(User::getId).toList()));
+    assertEquals(mappedMatch.getUsers().size(), mappedMatch.getOutcome().size());
+    assertTrue(mappedMatch.getUsers().stream()
+        .allMatch(user -> mappedMatch.getOutcome().containsKey(user.getToken())));
   }
 
   @Test
@@ -49,5 +52,8 @@ public class MatchRestMapperTest {
     assertTrue(mappedMatch.getUsers().stream().map(User::getId).toList()
         .containsAll(
             updateMatchCommand().users().stream().map(User::getId).toList()));
+    assertEquals(mappedMatch.getUsers().size(), mappedMatch.getOutcome().size());
+    assertTrue(mappedMatch.getUsers().stream()
+        .allMatch(user -> mappedMatch.getOutcome().containsKey(user.getToken())));
   }
 }

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/entity/MatchEntity.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/entity/MatchEntity.java
@@ -1,7 +1,9 @@
 package com.gepardec.adapter.output.persistence.entity;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
@@ -10,8 +12,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKeyJoinColumn;
 import jakarta.persistence.Table;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Entity
 @Table(name = "matches", indexes = @Index(name = "ux_matches_token", columnList = "token", unique = true))
@@ -29,6 +34,14 @@ public class MatchEntity extends AbstractEntity {
   @JoinColumn(nullable = false, name = "fk_match", foreignKey = @ForeignKey(name = "fk_match")), inverseJoinColumns =
   @JoinColumn(nullable = false, name = "fk_user", foreignKey = @ForeignKey(name = "fk_user")))
   private List<UserEntity> users;
+
+  //placement per participating user (1-based, tied users share a placement); empty for matches created before outcomes existed
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(name = "match_placements", joinColumns =
+  @JoinColumn(nullable = false, name = "fk_match", foreignKey = @ForeignKey(name = "fk_match_placements_match")))
+  @MapKeyJoinColumn(name = "fk_user", foreignKey = @ForeignKey(name = "fk_match_placements_user"))
+  @Column(name = "placement", nullable = false)
+  private Map<UserEntity, Integer> placements = new HashMap<>();
 
   public MatchEntity() {
 
@@ -55,6 +68,14 @@ public class MatchEntity extends AbstractEntity {
 
   public void setUsers(List<UserEntity> users) {
     this.users = users;
+  }
+
+  public Map<UserEntity, Integer> getPlacements() {
+    return placements;
+  }
+
+  public void setPlacements(Map<UserEntity, Integer> placements) {
+    this.placements = placements;
   }
 
   public String getToken() {

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/mapper/MatchMapper.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/repository/mapper/MatchMapper.java
@@ -11,6 +11,7 @@ import jakarta.persistence.PersistenceContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -31,10 +32,14 @@ public class MatchMapper {
 
   public Match matchEntityToMatchModel(MatchEntity matchEntity) {
 
-    return new Match(matchEntity.getId(), matchEntity.getToken(),
+    Match match = new Match(matchEntity.getId(), matchEntity.getToken(),
             matchEntity.getCreatedOn(), matchEntity.getUpdatedOn(),
             gameMapper.gameEntityToGameModel(matchEntity.getGame()),
         matchEntity.getUsers().stream().map(userMapper::userEntityToUserModel).toList());
+    match.setOutcome(matchEntity.getPlacements().entrySet().stream()
+        .collect(Collectors.toMap(placement -> placement.getKey().getToken(),
+            Map.Entry::getValue)));
+    return match;
   }
 
   public MatchEntity matchModelToMatchEntity(Match match) {
@@ -43,8 +48,13 @@ public class MatchMapper {
         new UserEntity(user.getId(), user.getFirstname(), user.getLastname(),
             user.isDeactivated(), user.getToken())));
 
-    return new MatchEntity(match.getId(), match.getToken(),
+    MatchEntity matchEntity = new MatchEntity(match.getId(), match.getToken(),
         gameMapper.gameModelToGameEntity(match.getGame()), users);
+    matchEntity.setPlacements(users.stream()
+        .filter(user -> match.getOutcome().containsKey(user.getToken()))
+        .collect(Collectors.toMap(user -> user,
+            user -> match.getOutcome().get(user.getToken()))));
+    return matchEntity;
   }
 
   public MatchEntity matchModelToMatchEntityWithReference(Match match, MatchEntity matchEntity) {
@@ -55,6 +65,12 @@ public class MatchMapper {
         match.getUsers().stream()
             .map(u -> entityManager.getReference(UserEntity.class, u.getId()))
             .collect(Collectors.toList()));
+    matchEntity.getPlacements().clear();
+    match.getUsers().stream()
+        .filter(u -> match.getOutcome().containsKey(u.getToken()))
+        .forEach(u -> matchEntity.getPlacements().put(
+            entityManager.getReference(UserEntity.class, u.getId()),
+            match.getOutcome().get(u.getToken())));
     matchEntity.setToken(match.getToken());
     return matchEntity;
   }

--- a/gamertrack-db/src/test/java/com/gepardec/adapter/output/persistence/repository/MatchRepositoryTest.java
+++ b/gamertrack-db/src/test/java/com/gepardec/adapter/output/persistence/repository/MatchRepositoryTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.gepardec.TestFixtures.*;
@@ -58,6 +59,41 @@ public class MatchRepositoryTest  {
     Assertions.assertEquals(match.getGame().getName(), savedAndReadMatch.get().getGame().getName());
     Assertions.assertEquals(match.getUsers().getFirst().getFirstname(),
         savedAndReadMatch.get().getUsers().getFirst().getFirstname());
+  }
+
+  @Test
+  public void ensureSaveAndReadMatchPersistsOutcomeIndependentOfUserOrder() {
+    Optional<Game> savedGame = gameRepository.saveGame(game(null));
+    List<User> users = users(1);
+    Optional<User> savedUser1 = userRepository.saveUser(users.getFirst());
+    Optional<User> savedUser2 = userRepository.saveUser(users.getLast());
+    Match match = match(null);
+    match.setGame(savedGame.get());
+    match.setUsers(List.of(savedUser1.get(), savedUser2.get()));
+    match.setOutcome(Map.of(
+        savedUser1.get().getToken(), 2,
+        savedUser2.get().getToken(), 1));
+
+    var savedAndReadMatch = matchRepository.saveMatch(match);
+
+    Assertions.assertTrue(savedAndReadMatch.isPresent());
+    Assertions.assertEquals(match.getOutcome(), savedAndReadMatch.get().getOutcome());
+  }
+
+  @Test
+  public void ensureReadingMatchWithoutOutcomeReturnsEmptyOutcome() {
+    //matches created before outcomes existed have no placements and must stay readable
+    Optional<Game> savedGame = gameRepository.saveGame(game(null));
+    Optional<User> savedUser = userRepository.saveUser(users(1).getFirst());
+    Match match = match(null);
+    match.setGame(savedGame.get());
+    match.setUsers(List.of(savedUser.get()));
+    match.setOutcome(Map.of());
+
+    var savedAndReadMatch = matchRepository.saveMatch(match);
+
+    Assertions.assertTrue(savedAndReadMatch.isPresent());
+    Assertions.assertTrue(savedAndReadMatch.get().getOutcome().isEmpty());
   }
 
   @Test

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/EloService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/EloService.java
@@ -2,12 +2,12 @@ package com.gepardec.core.services;
 
 import com.gepardec.model.Game;
 import com.gepardec.model.Score;
-import com.gepardec.model.User;
 
 import java.util.List;
+import java.util.Map;
 
 public interface EloService {
     double expectedProbability(double playerScore, double opponentScore);
     double calculateNewScore(double oldScore, double expectedProbability, double result);
-    List<Score> updateElo(Game game, List<Score> ScoreList, List<User> playerOrder);
+    List<Score> updateElo(Game game, List<Score> ScoreList, Map<String, Integer> placements);
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/EloServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/EloServiceImpl.java
@@ -3,12 +3,14 @@ package com.gepardec.impl.service;
 import com.gepardec.core.services.EloService;
 import com.gepardec.model.Game;
 import com.gepardec.model.Score;
-import com.gepardec.model.User;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Transactional
 @ApplicationScoped
@@ -27,36 +29,32 @@ public class EloServiceImpl implements EloService {
         return (int) Math.round(oldScore + K * (result - expectedProbability));
     }
 
-    public List<Score> updateElo(Game game, final List<Score> scoreList, List<User> playerOrder) {
+    public List<Score> updateElo(Game game, final List<Score> scoreList, Map<String, Integer> placements) {
 
-        int numPlayers = playerOrder.size();
-        List<Score> results = new ArrayList<>();
+        int numPlayers = scoreList.size();
         List<Score> UpdatedScoreList = new ArrayList<>();
         for( Score score : scoreList ) {
             UpdatedScoreList.add(new Score(score.getId(),score.getUser(),score.getGame(),score.getScorePoints(),score.getToken(),false));
         }
 
-        for (int i = 0; i < numPlayers; i++) {
-            User user = playerOrder.get(i);
-            double score = 1.0 - (i / (double) (numPlayers - 1));
-            results.add(new Score(0L,user, game, score,"",false));
-        }
+        Map<Integer, Long> tiedPlayersPerPlacement = placements.values().stream()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
         for (int i = 0; i < numPlayers; i++) {
-            User user = playerOrder.get(i);
-            double playerRating = scoreList.stream().filter(x -> x.getUser().getToken() == user.getToken()).toList().getFirst().getScorePoints();
+            Score playerScore = scoreList.get(i);
+            double playerRating = playerScore.getScorePoints();
 
             double totalExpectedProbability = 0.0;
             for (int j = 0; j < numPlayers; j++) {
                 if (i != j) {
-                    User opponent = playerOrder.get(j);
-                    double opponentRating = scoreList.stream().filter(x -> x.getUser().getToken() == opponent.getToken()).toList().getFirst().getScorePoints();
-                    totalExpectedProbability += expectedProbability(playerRating, opponentRating);
-
+                    totalExpectedProbability += expectedProbability(playerRating, scoreList.get(j).getScorePoints());
                 }
             }
 
-            double result = results.stream().filter(x -> x.getUser().getToken() == user.getToken()).toList().getFirst().getScorePoints();
+            //tied players share the result of the positions they occupy together (average of those positions' results)
+            int placement = placements.get(playerScore.getUser().getToken());
+            long tiedPlayers = tiedPlayersPerPlacement.get(placement);
+            double result = 1.0 - (placement - 1 + (tiedPlayers - 1) / 2.0) / (numPlayers - 1);
             double expectedResult = totalExpectedProbability / (numPlayers - 1);
 
             double newRating = calculateNewScore(playerRating, expectedResult, result);

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/MatchServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/MatchServiceImpl.java
@@ -20,7 +20,12 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @ApplicationScoped
 @Transactional
@@ -83,6 +88,11 @@ public class MatchServiceImpl implements MatchService {
                     && foundUsers.size() == match.getUsers().size()
                     && foundGame.isPresent()) {
 
+                if (!hasValidOutcome(foundUsers, match.getOutcome())) {
+                    logger.error("Match outcome is invalid: %s".formatted(match.getOutcome()));
+                    return Optional.empty();
+                }
+
                 match.setToken(tokenService.generateToken());
                 match.setGame(foundGame.get());
                 match.setUsers(foundUsers);
@@ -100,7 +110,7 @@ public class MatchServiceImpl implements MatchService {
                     scoreList.add(filteredScores.isEmpty() ? null : filteredScores.getFirst());
                 }
 
-                List<Score> updatedScores = eloService.updateElo(match.getGame(), scoreList, match.getUsers());
+                List<Score> updatedScores = eloService.updateElo(match.getGame(), scoreList, match.getOutcome());
                 for (Score score : updatedScores) {
                     scoreService.updateScore(score);
                 }
@@ -160,6 +170,11 @@ public class MatchServiceImpl implements MatchService {
                 && foundGame.isPresent()
                 && foundMatch.isPresent()) {
 
+            if (!hasValidOutcome(foundUsers, match.getOutcome())) {
+                logger.error("Match outcome is invalid: %s".formatted(match.getOutcome()));
+                return Optional.empty();
+            }
+
             match.setGame(foundGame.get());
             match.setUsers(foundUsers);
             match.setId(matchRepository.findMatchByToken(match.getToken()).get().getId());
@@ -175,6 +190,35 @@ public class MatchServiceImpl implements MatchService {
                 "Saving updated match with ID: %s aborted due to provided ID not existing".formatted(
                         match.getId()));
         return Optional.empty();
+    }
+
+    /**
+     * A valid outcome assigns every participating user exactly one placement following
+     * standard competition ranking: placements start at 1, tied users share a placement and
+     * each placement is followed by the placement skipping the tied users (e.g. 1,1,3 - not 1,1,2).
+     */
+    private boolean hasValidOutcome(List<User> users, Map<String, Integer> outcome) {
+        Set<String> userTokens = users.stream().map(User::getToken).collect(Collectors.toSet());
+
+        if (outcome == null || outcome.isEmpty() || !outcome.keySet().equals(userTokens)) {
+            return false;
+        }
+
+        if (outcome.values().stream().anyMatch(placement -> placement == null || placement < 1)) {
+            return false;
+        }
+
+        Map<Integer, Long> usersPerPlacement = outcome.values().stream()
+                .collect(Collectors.groupingBy(Function.identity(), TreeMap::new, Collectors.counting()));
+
+        int expectedPlacement = 1;
+        for (Map.Entry<Integer, Long> placement : usersPerPlacement.entrySet()) {
+            if (placement.getKey() != expectedPlacement) {
+                return false;
+            }
+            expectedPlacement += placement.getValue();
+        }
+        return true;
     }
 
     @Override

--- a/gamertrack-domain/src/main/java/com/gepardec/model/Match.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/model/Match.java
@@ -4,7 +4,9 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class Match {
@@ -15,6 +17,8 @@ public class Match {
     private Game game;
     @NotEmpty(message = "User List must not be null or Empty")
     private List<User> users;
+    //maps the token of a participating user to its placement (1-based, tied users share a placement)
+    private Map<String, Integer> outcome = new HashMap<>();
     private LocalDateTime createdOn;
     private LocalDateTime updatedOn;
 
@@ -35,6 +39,14 @@ public class Match {
         this.token = token;
         this.game = game;
         this.users = users;
+    }
+
+    public Match(Long id, String token, Game game, List<User> users, Map<String, Integer> outcome) {
+        this.id = id;
+        this.token = token;
+        this.game = game;
+        this.users = users;
+        this.outcome = outcome == null ? new HashMap<>() : outcome;
     }
 
     public Long getId() {
@@ -59,6 +71,14 @@ public class Match {
 
     public void setUsers(List<User> users) {
         this.users = users;
+    }
+
+    public Map<String, Integer> getOutcome() {
+        return outcome;
+    }
+
+    public void setOutcome(Map<String, Integer> outcome) {
+        this.outcome = outcome == null ? new HashMap<>() : outcome;
     }
 
     public String getToken() {
@@ -92,6 +112,7 @@ public class Match {
                 ", key='" + token + '\'' +
                 ", game=" + game +
                 ", users=" + users +
+                ", outcome=" + outcome +
                 '}';
     }
 
@@ -99,11 +120,11 @@ public class Match {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Match match = (Match) o;
-        return Objects.equals(id, match.id) && Objects.equals(token, match.token) && Objects.equals(game, match.game) && Objects.equals(users, match.users);
+        return Objects.equals(id, match.id) && Objects.equals(token, match.token) && Objects.equals(game, match.game) && Objects.equals(users, match.users) && Objects.equals(outcome, match.outcome);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, token, game, users);
+        return Objects.hash(id, token, game, users, outcome);
     }
 }

--- a/gamertrack-domain/src/test/java/com/gepardec/TestFixtures.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/TestFixtures.java
@@ -7,7 +7,9 @@ import com.gepardec.model.Score;
 import com.gepardec.model.User;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TestFixtures {
 
@@ -37,7 +39,16 @@ public class TestFixtures {
 
 
   public static Match match(Long id, Game game, List<User> users) {
-    return new Match(id, tokenService.generateToken(), game, users.stream().toList());
+    return new Match(id, tokenService.generateToken(), game, users.stream().toList(),
+        outcome(users));
+  }
+
+  public static Map<String, Integer> outcome(List<User> users) {
+    Map<String, Integer> outcome = new HashMap<>();
+    for (int i = 0; i < users.size(); i++) {
+      outcome.put(users.get(i).getToken(), i + 1);
+    }
+    return outcome;
   }
 
   public static List<User> users(int userCount) {

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/EloServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/EloServiceImplTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -86,9 +87,14 @@ public class EloServiceImplTest {
         Score score5 = new Score(0L,user5,game,1500,"",true);
 
         List<Score> scoresList = List.of(score1,score2, score3, score4, score5);
-        List<User> usersList = List.of(user1,user2, user3, user4, user5);
+        Map<String, Integer> placements = Map.of(
+                user1.getToken(), 1,
+                user2.getToken(), 2,
+                user3.getToken(), 3,
+                user4.getToken(), 4,
+                user5.getToken(), 5);
 
-        List<Score> updatedScoresList = eloService.updateElo(game, scoresList,usersList);
+        List<Score> updatedScoresList = eloService.updateElo(game, scoresList, placements);
 
         assertEquals(1516, updatedScoresList.get(0).getScorePoints());
         assertEquals(1508, updatedScoresList.get(1).getScorePoints());
@@ -97,6 +103,61 @@ public class EloServiceImplTest {
         assertEquals(1484, updatedScoresList.get(4).getScorePoints());
 
 
+    }
+
+    @Test
+    void ensureUpdatingEloFollowsPlacementsInsteadOfListOrder(){
+        Game game = TestFixtures.game();
+
+        User user1 = TestFixtures.user(0L);
+        User user2 = TestFixtures.user(1L);
+
+        Score score1 = new Score(0L,user1,game,1500,"",true);
+        Score score2 = new Score(0L,user2,game,1500,"",true);
+
+        List<Score> updatedScoresList = eloService.updateElo(game, List.of(score1, score2),
+                Map.of(user1.getToken(), 2, user2.getToken(), 1));
+
+        assertEquals(1484, updatedScoresList.get(0).getScorePoints());
+        assertEquals(1516, updatedScoresList.get(1).getScorePoints());
+    }
+
+    @Test
+    void ensureUpdatingEloForDrawWithEqualRatingsChangesNothing(){
+        Game game = TestFixtures.game();
+
+        User user1 = TestFixtures.user(0L);
+        User user2 = TestFixtures.user(1L);
+
+        Score score1 = new Score(0L,user1,game,1500,"",true);
+        Score score2 = new Score(0L,user2,game,1500,"",true);
+
+        List<Score> updatedScoresList = eloService.updateElo(game, List.of(score1, score2),
+                Map.of(user1.getToken(), 1, user2.getToken(), 1));
+
+        assertEquals(1500, updatedScoresList.get(0).getScorePoints());
+        assertEquals(1500, updatedScoresList.get(1).getScorePoints());
+    }
+
+    @Test
+    void ensureUpdatingEloWithSharedFirstPlaceGivesTiedPlayersTheSharedResult(){
+        Game game = TestFixtures.game();
+
+        User user1 = TestFixtures.user(0L);
+        User user2 = TestFixtures.user(1L);
+        User user3 = TestFixtures.user(2L);
+
+        Score score1 = new Score(0L,user1,game,1500,"",true);
+        Score score2 = new Score(0L,user2,game,1500,"",true);
+        Score score3 = new Score(0L,user3,game,1500,"",true);
+
+        //tied first place shares the results of positions 1 and 2 -> (1.0 + 0.5) / 2 = 0.75 each
+        List<Score> updatedScoresList = eloService.updateElo(game, List.of(score1, score2, score3),
+                Map.of(user1.getToken(), 1, user2.getToken(), 1, user3.getToken(), 3));
+
+        assertEquals(1508, updatedScoresList.get(0).getScorePoints());
+        assertEquals(1508, updatedScoresList.get(1).getScorePoints());
+        assertEquals(1484, updatedScoresList.get(2).getScorePoints());
     }
 
 }

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/MatchServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/MatchServiceImplTest.java
@@ -16,7 +16,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.gepardec.TestFixtures.match;
@@ -68,6 +70,99 @@ class MatchServiceImplTest {
 
         assertEquals(matchService.saveMatch(match).get().getId(),
                 match().getId());
+    }
+
+    @Test
+    void ensureSavingMatchWithoutOutcomeReturnsEmptyOptional() {
+        Match match = match();
+        match.setOutcome(new HashMap<>());
+
+        stubExistingGameAndUsers(match);
+
+        assertEquals(Optional.empty(), matchService.saveMatch(match));
+    }
+
+    @Test
+    void ensureSavingMatchWithPlacementGapReturnsEmptyOptional() {
+        Match match = match(1L, TestFixtures.game(), TestFixtures.usersWithId(1));
+        match.setOutcome(Map.of(
+                match.getUsers().get(0).getToken(), 1,
+                match.getUsers().get(1).getToken(), 3));
+
+        stubExistingGameAndUsers(match);
+
+        assertEquals(Optional.empty(), matchService.saveMatch(match));
+    }
+
+    @Test
+    void ensureSavingMatchWithOutcomeForUnknownUserReturnsEmptyOptional() {
+        Match match = match(1L, TestFixtures.game(), TestFixtures.usersWithId(1));
+        match.setOutcome(Map.of(
+                match.getUsers().get(0).getToken(), 1,
+                "unknownUserToken", 2));
+
+        stubExistingGameAndUsers(match);
+
+        assertEquals(Optional.empty(), matchService.saveMatch(match));
+    }
+
+    @Test
+    void ensureSavingMatchWithParticipantWithoutPlacementReturnsEmptyOptional() {
+        Match match = match(1L, TestFixtures.game(), TestFixtures.usersWithId(1));
+        match.setOutcome(Map.of(match.getUsers().get(0).getToken(), 1));
+
+        stubExistingGameAndUsers(match);
+
+        assertEquals(Optional.empty(), matchService.saveMatch(match));
+    }
+
+    @Test
+    void ensureSavingMatchWithNonPositivePlacementReturnsEmptyOptional() {
+        Match match = match(1L, TestFixtures.game(), TestFixtures.usersWithId(1));
+        match.setOutcome(Map.of(
+                match.getUsers().get(0).getToken(), 0,
+                match.getUsers().get(1).getToken(), 1));
+
+        stubExistingGameAndUsers(match);
+
+        assertEquals(Optional.empty(), matchService.saveMatch(match));
+    }
+
+    @Test
+    void ensureSavingMatchWithTieNotSkippingFollowingPlacementReturnsEmptyOptional() {
+        Match match = match(1L, TestFixtures.game(), TestFixtures.usersWithId(2));
+        match.setOutcome(Map.of(
+                match.getUsers().get(0).getToken(), 1,
+                match.getUsers().get(1).getToken(), 1,
+                match.getUsers().get(2).getToken(), 2));
+
+        stubExistingGameAndUsers(match);
+
+        assertEquals(Optional.empty(), matchService.saveMatch(match));
+    }
+
+    @Test
+    void ensureSavingMatchWithTieSkippingFollowingPlacementWorks() {
+        Match match = match(1L, TestFixtures.game(), TestFixtures.usersWithId(2));
+        match.setOutcome(Map.of(
+                match.getUsers().get(0).getToken(), 1,
+                match.getUsers().get(1).getToken(), 1,
+                match.getUsers().get(2).getToken(), 3));
+
+        stubExistingGameAndUsers(match);
+        when(tokenService.generateToken()).thenReturn(match.getToken());
+        when(matchRepository.saveMatch(any())).thenReturn(Optional.of(match));
+
+        assertEquals(match.getId(), matchService.saveMatch(match).get().getId());
+    }
+
+    private void stubExistingGameAndUsers(Match match) {
+        when(gameRepository.findGameByToken(anyString())).thenReturn(
+                Optional.of(match.getGame()));
+        when(userRepository.findUserByToken(anyString())).thenAnswer(
+                invocation -> match.getUsers().stream()
+                        .filter(user -> user.getToken().equals(invocation.getArgument(0)))
+                        .findFirst());
     }
 
     @Test
@@ -168,6 +263,25 @@ class MatchServiceImplTest {
 
         //Then
         assertEquals(matchNew.getId(), updatedMatch.get().getId());
+    }
+
+    @Test
+    void ensureUpdateMatchWithInvalidOutcomeReturnsEmptyOptional() {
+        //Given
+        Match matchNew = match(1L);
+        matchNew.setOutcome(Map.of(matchNew.getUsers().getFirst().getToken(), 1));
+
+        //When
+        when(gameRepository.findGameByToken(anyString())).thenReturn(Optional.of(matchNew.getGame()));
+        when(userRepository.findUserByToken(anyString())).thenAnswer(
+                invocation -> matchNew.getUsers().stream()
+                        .filter(user -> user.getToken().equals(invocation.getArgument(0))).findFirst());
+        when(matchRepository.findMatchByToken(anyString())).thenReturn(Optional.of(matchNew));
+
+        var updatedMatch = matchService.updateMatch(matchNew);
+
+        //Then
+        assertEquals(Optional.empty(), updatedMatch);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements LAKWYC-4: a match's result is now explicit, stored data instead of being encoded in the order of the users list.

- **Domain/DB**: `Match` carries an `outcome` map (user token → 1-based placement); persisted in a new `match_placements` collection table (`fk_match`, `fk_user`, `placement`). Matches created before this feature stay readable with an empty outcome.
- **Validation** (create and update): every participant needs exactly one placement, no placements for unknown users, placements start at 1, ties allowed — tied users share a placement and the next placement skips the tied group (1,1,3 valid; 1,1,2 and gaps rejected). Invalid outcomes → 400.
- **Elo**: the rating calculation is driven by the stored placements instead of list order. Without ties the rating changes are bit-identical to the previous behavior; tied players share the averaged result of the positions they occupy (1v1 draw at equal ratings → no change).
- **API/OpenAPI**: `outcome` added to `CreateMatchCommand`, `UpdateMatchCommand` and `MatchRestDto` (list + detail responses) with schema docs; endpoints unchanged otherwise and still secured via `@Secure`. Frontend adaptation is a separate ticket.

## Tests

- Unit: Elo draw/tie/order-independence, all outcome validation cases, REST + persistence mappers, repository round-trip incl. legacy match without outcome.
- Integration: 1v1 and 4-player creation, draw (ratings verified unchanged), placements overriding request user order (ratings follow placements), read-back stability, all garbage inputs → 400, tie rank skipping, outcome correction via update.

Verified locally: `./mvnw install` — 145 unit tests green; `./mvnw verify -Prun-integrationtests` — 57 ITs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)