### PR TITLE
fix: LAKWYC-5 Elo score lookup by token equality instead of reference identity

### DIFF
--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/EloServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/EloServiceImpl.java
@@ -9,6 +9,7 @@ import jakarta.transaction.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Transactional
 @ApplicationScoped
@@ -31,9 +32,9 @@ public class EloServiceImpl implements EloService {
 
         int numPlayers = playerOrder.size();
         List<Score> results = new ArrayList<>();
-        List<Score> UpdatedScoreList = new ArrayList<>();
+        List<Score> updatedScoreList = new ArrayList<>();
         for( Score score : scoreList ) {
-            UpdatedScoreList.add(new Score(score.getId(),score.getUser(),score.getGame(),score.getScorePoints(),score.getToken(),false));
+            updatedScoreList.add(new Score(score.getId(),score.getUser(),score.getGame(),score.getScorePoints(),score.getToken(),false));
         }
 
         for (int i = 0; i < numPlayers; i++) {
@@ -44,26 +45,35 @@ public class EloServiceImpl implements EloService {
 
         for (int i = 0; i < numPlayers; i++) {
             User user = playerOrder.get(i);
-            double playerRating = scoreList.stream().filter(x -> x.getUser().getToken() == user.getToken()).toList().getFirst().getScorePoints();
+            double playerRating = findScoreByUserToken(scoreList, user).getScorePoints();
 
             double totalExpectedProbability = 0.0;
             for (int j = 0; j < numPlayers; j++) {
                 if (i != j) {
                     User opponent = playerOrder.get(j);
-                    double opponentRating = scoreList.stream().filter(x -> x.getUser().getToken() == opponent.getToken()).toList().getFirst().getScorePoints();
+                    double opponentRating = findScoreByUserToken(scoreList, opponent).getScorePoints();
                     totalExpectedProbability += expectedProbability(playerRating, opponentRating);
 
                 }
             }
 
-            double result = results.stream().filter(x -> x.getUser().getToken() == user.getToken()).toList().getFirst().getScorePoints();
+            double result = findScoreByUserToken(results, user).getScorePoints();
             double expectedResult = totalExpectedProbability / (numPlayers - 1);
 
             double newRating = calculateNewScore(playerRating, expectedResult, result);
 
-            UpdatedScoreList.get(i).setScorePoints(newRating);
-            UpdatedScoreList.get(i).setDeletable(false);
+            Score updatedScore = findScoreByUserToken(updatedScoreList, user);
+            updatedScore.setScorePoints(newRating);
+            updatedScore.setDeletable(false);
         }
-        return UpdatedScoreList;
+        return updatedScoreList;
+    }
+
+    private Score findScoreByUserToken(List<Score> scores, User user) {
+        return scores.stream()
+                .filter(score -> Objects.equals(score.getUser().getToken(), user.getToken()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No score found for user with token '%s'".formatted(user.getToken())));
     }
 }

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/EloServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/EloServiceImplTest.java
@@ -13,6 +13,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -97,6 +99,79 @@ public class EloServiceImplTest {
         assertEquals(1484, updatedScoresList.get(4).getScorePoints());
 
 
+    }
+
+    @Test
+    void ensureUpdatingEloWorksWithDistinctUserInstancesCarryingEqualTokens() {
+        Game game = TestFixtures.game();
+
+        User winner = new User(1L, "Max", "Muster", false, "elo-user-token-1");
+        User loser = new User(2L, "Jakob", "Mayer", false, "elo-user-token-2");
+
+        // score users are distinct instances whose tokens are equal but not identical,
+        // so a reference comparison on the token can never match
+        Score winnerScore = new Score(1L, new User(1L, "Max", "Muster", false, new String("elo-user-token-1")), game, 1500, "", true);
+        Score loserScore = new Score(2L, new User(2L, "Jakob", "Mayer", false, new String("elo-user-token-2")), game, 1500, "", true);
+
+        List<Score> updatedScoresList = eloService.updateElo(game, List.of(winnerScore, loserScore), List.of(winner, loser));
+
+        assertEquals(1516, scorePointsOf(updatedScoresList, winner));
+        assertEquals(1484, scorePointsOf(updatedScoresList, loser));
+    }
+
+    @Test
+    void ensureUpdatingEloAssignsRatingsByUserWhenScoreListOrderDiffersFromPlayerOrder() {
+        Game game = TestFixtures.game();
+
+        User winner = TestFixtures.user(1L);
+        User loser = TestFixtures.user(2L);
+
+        Score winnerScore = new Score(1L, winner, game, 1500, "", true);
+        Score loserScore = new Score(2L, loser, game, 1500, "", true);
+
+        List<Score> updatedScoresList = eloService.updateElo(game, List.of(loserScore, winnerScore), List.of(winner, loser));
+
+        assertEquals(1516, scorePointsOf(updatedScoresList, winner));
+        assertEquals(1484, scorePointsOf(updatedScoresList, loser));
+    }
+
+    @Test
+    void ensureUpdatingEloWithTwoEquallyRatedPlayersGrantsAndDeductsSameAmount() {
+        Game game = TestFixtures.game();
+
+        User winner = TestFixtures.user(1L);
+        User loser = TestFixtures.user(2L);
+
+        Score winnerScore = new Score(1L, winner, game, 1500, "", true);
+        Score loserScore = new Score(2L, loser, game, 1500, "", true);
+
+        List<Score> updatedScoresList = eloService.updateElo(game, List.of(winnerScore, loserScore), List.of(winner, loser));
+
+        assertEquals(1516, scorePointsOf(updatedScoresList, winner));
+        assertEquals(1484, scorePointsOf(updatedScoresList, loser));
+    }
+
+    @Test
+    void ensureUpdatingEloFailsWithDescriptiveErrorWhenScoreForPlayerIsMissing() {
+        Game game = TestFixtures.game();
+
+        User user1 = TestFixtures.user(1L);
+        User user2 = TestFixtures.user(2L);
+
+        Score score1 = new Score(1L, user1, game, 1500, "", true);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> eloService.updateElo(game, List.of(score1), List.of(user1, user2)));
+
+        assertTrue(exception.getMessage().contains(user2.getToken()));
+    }
+
+    private static double scorePointsOf(List<Score> scores, User user) {
+        return scores.stream()
+                .filter(score -> user.getToken().equals(score.getUser().getToken()))
+                .findFirst()
+                .orElseThrow()
+                .getScorePoints();
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes LAKWYC-5: the Elo service matched scores to players via **reference comparison** on token `String`s (`x.getUser().getToken() == user.getToken()`), which only worked because the persistence context happened to return the identical `User` instance for both the found user and the user attached to the score. The new rating was also written back **positionally** (`updatedScoreList.get(i)` indexed by player order), relying on the caller building both lists in the same order.

### Changes
- All token comparisons now use `Objects.equals()` via a single `findScoreByUserToken` helper.
- The rating write-back is keyed by user token, not list position — a score list ordered differently from the player order still yields correct per-player ratings.
- A missing score fails with a descriptive `IllegalArgumentException` instead of an incidental `NoSuchElementException` from `getFirst()`.

### Tests
New unit tests in `EloServiceImplTest` (all verified to fail on the previous implementation where the ticket predicts it):
- distinct user/score instances carrying **equal but not identical** tokens → correct ratings (previously `NoSuchElementException`)
- score list **reversed** relative to player order → each player gets their own rating (previously silently swapped: 1484 where 1516 belongs)
- two equally rated players (1500 vs 1500) → winner +16 / loser −16, confirming the math is unchanged
- player without a matching score → descriptive error naming the token

The end-to-end guard already exists as `EloServiceImplIT.ensureStartMatchChangesEloScoreCorrectly` (match creation through the REST API → 1516/1484).

### Verification
- `./mvnw clean install` — 136 unit tests, 0 failures
- `./mvnw verify -Prun-integrationtests` — 49 integration tests incl. `EloServiceImplIT` and `MatchResourceImplIT`, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)