### PR TITLE
fix: LAKWYC-7 persist user order of a match with an explicit order column

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ classDiagram
     Game "1" *-- "0..n" Score
 ```
 
+### Match user order
+
+The order of the users of a match carries meaning: index 0 is the winner,
+followed by 2nd, 3rd, ... place. It drives the Elo calculation and the
+placement display in the frontend. The position is therefore stored
+explicitly in the `user_order` column of the `matches_users` join table, so
+reading a match always returns exactly the order it was created with.
+
+Migration note: the application currently recreates the schema on every
+startup (`quarkus.hibernate-orm.schema-management.strategy=drop-and-create`
+on an in-memory H2 database), so no rows without a `user_order` value can
+exist. If the application is ever pointed at a persistent database that
+predates this column, `user_order` (NOT NULL) must be backfilled for
+existing `matches_users` rows before startup — e.g. numbering each match's
+rows 0..n-1 in a deliberate, stable order such as by `fk_user`.
+
 ## HTTPS-ENDPOINTS
 
 Rest-Endpoints are available via

--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/MatchResourceImplIT.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/MatchResourceImplIT.java
@@ -370,6 +370,53 @@ public class MatchResourceImplIT {
     }
 
     @Test
+    void ensureMatchUsersAreReturnedInCreationOrderOnEveryFreshRead() {
+        GameRestDto createdGame = createGame();
+        UserRestDto userC = createUser("Charlie");
+        UserRestDto userA = createUser("Alice");
+        UserRestDto userB = createUser("Bob");
+        UserRestDto userD = createUser("Dora");
+
+        MatchRestDto createdMatch1 = createMatch(List.of(userC, userA, userB, userD), createdGame);
+        MatchRestDto createdMatch2 = createMatch(List.of(userD, userB, userC, userA), createdGame);
+
+        List<String> expectedOrder1 = List.of(
+                userC.token(), userA.token(), userB.token(), userD.token());
+        List<String> expectedOrder2 = List.of(
+                userD.token(), userB.token(), userC.token(), userA.token());
+
+        assertEquals(expectedOrder1,
+                createdMatch1.users().stream().map(UserRestDto::token).toList());
+        assertEquals(expectedOrder2,
+                createdMatch2.users().stream().map(UserRestDto::token).toList());
+
+        // every fresh request returns the creation order of the respective match
+        for (int i = 0; i < 2; i++) {
+            MatchRestDto foundMatch1 = given()
+                    .pathParam("token", createdMatch1.token())
+                    .when()
+                    .get("%s/{token}".formatted(MATCH_PATH))
+                    .then()
+                    .statusCode(Status.OK.getStatusCode())
+                    .extract()
+                    .as(MatchRestDto.class);
+            MatchRestDto foundMatch2 = given()
+                    .pathParam("token", createdMatch2.token())
+                    .when()
+                    .get("%s/{token}".formatted(MATCH_PATH))
+                    .then()
+                    .statusCode(Status.OK.getStatusCode())
+                    .extract()
+                    .as(MatchRestDto.class);
+
+            assertEquals(expectedOrder1,
+                    foundMatch1.users().stream().map(UserRestDto::token).toList());
+            assertEquals(expectedOrder2,
+                    foundMatch2.users().stream().map(UserRestDto::token).toList());
+        }
+    }
+
+    @Test
     void ensureUpdateMatchForExistingMatchReturns200OkWithUpdatedMatch() {
         MatchRestDto existingMatch = createMatch();
         UserRestDto userRestDto = createUser();
@@ -471,6 +518,10 @@ public class MatchResourceImplIT {
 
     //-------------------HELPER METHODS -------------------------//
     public UserRestDto createUser() {
+        return createUser("max");
+    }
+
+    public UserRestDto createUser(String firstname) {
         UserRestDto userRestDto =
                 with()
                         .contentType("application/json")
@@ -481,7 +532,7 @@ public class MatchResourceImplIT {
                                 ContentType.JSON,
                                 "Accept",
                                 ContentType.JSON)
-                        .body(new CreateUserCommand("max", "Muster"))
+                        .body(new CreateUserCommand(firstname, "Muster"))
                         .post(USER_PATH)
                         .then()
                         .statusCode(Status.CREATED.getStatusCode())
@@ -521,12 +572,16 @@ public class MatchResourceImplIT {
     }
 
     public MatchRestDto createMatch(UserRestDto userRestDto1, UserRestDto userRestDto2, GameRestDto gameRestDto) {
+        return createMatch(List.of(userRestDto1, userRestDto2), gameRestDto);
+    }
+
+    public MatchRestDto createMatch(List<UserRestDto> userRestDtos, GameRestDto gameRestDto) {
         CreateMatchCommand createMatchCommand = new CreateMatchCommand(
                 new Game(null, gameRestDto.token(), gameRestDto.name(), gameRestDto.rules()),
-                List.of(new User(null, userRestDto1.firstname(), userRestDto1.lastname(),
-                                userRestDto1.deactivated(), userRestDto1.token()),
-                        new User(null, userRestDto2.firstname(), userRestDto2.lastname(),
-                                userRestDto2.deactivated(), userRestDto2.token())));
+                userRestDtos.stream()
+                        .map(urd -> new User(null, urd.firstname(), urd.lastname(),
+                                urd.deactivated(), urd.token()))
+                        .toList());
 
         MatchRestDto createdMatch =
                 with()

--- a/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/entity/MatchEntity.java
+++ b/gamertrack-db/src/main/java/com/gepardec/adapter/output/persistence/entity/MatchEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
 import java.util.List;
 
@@ -24,10 +25,15 @@ public class MatchEntity extends AbstractEntity {
   @JoinColumn(name = "fk_game_match", foreignKey = @ForeignKey(name = "fk_game_match"))
   private GameEntity game;
 
+  // The list order is semantically meaningful (index 0 = winner, then 2nd, 3rd, ...):
+  // the Elo calculation and the frontend placement display rely on it, so the
+  // position of every user is persisted explicitly. When attaching a database that
+  // predates the user_order column, it must be backfilled (NOT NULL) before startup.
   @ManyToMany(cascade = CascadeType.MERGE, fetch = FetchType.EAGER)
   @JoinTable(name = "matches_users", joinColumns =
   @JoinColumn(nullable = false, name = "fk_match", foreignKey = @ForeignKey(name = "fk_match")), inverseJoinColumns =
   @JoinColumn(nullable = false, name = "fk_user", foreignKey = @ForeignKey(name = "fk_user")))
+  @OrderColumn(name = "user_order", nullable = false)
   private List<UserEntity> users;
 
   public MatchEntity() {

--- a/gamertrack-db/src/test/java/com/gepardec/adapter/output/persistence/repository/MatchRepositoryTest.java
+++ b/gamertrack-db/src/test/java/com/gepardec/adapter/output/persistence/repository/MatchRepositoryTest.java
@@ -240,6 +240,78 @@ public class MatchRepositoryTest  {
   }
 
   @Test
+  public void ensureMatchUsersAreReturnedInCreationOrder() {
+    Game game = gameRepository.saveGame(game(null)).orElseThrow();
+    List<User> savedUsers = users(2).stream()
+        .map(u -> userRepository.saveUser(u).orElseThrow())
+        .toList();
+    User userC = savedUsers.get(0);
+    User userA = savedUsers.get(1);
+    User userB = savedUsers.get(2);
+
+    Match savedMatch = matchRepository.saveMatch(
+        match(null, game, List.of(userC, userA, userB))).orElseThrow();
+
+    List<String> expectedTokenOrder = List.of(
+        userC.getToken(), userA.getToken(), userB.getToken());
+
+    Assertions.assertEquals(expectedTokenOrder,
+        savedMatch.getUsers().stream().map(User::getToken).toList());
+
+    // re-read in a fresh transaction, twice, to ensure the order is stable
+    for (int i = 0; i < 2; i++) {
+      Match rereadMatch = matchRepository.findMatchById(savedMatch.getId()).orElseThrow();
+      Assertions.assertEquals(expectedTokenOrder,
+          rereadMatch.getUsers().stream().map(User::getToken).toList());
+    }
+  }
+
+  @Test
+  public void ensureInterleavedMatchesEachKeepTheirOwnUserOrder() {
+    Game game = gameRepository.saveGame(game(null)).orElseThrow();
+    List<User> savedUsers = users(3).stream()
+        .map(u -> userRepository.saveUser(u).orElseThrow())
+        .toList();
+
+    List<User> orderMatch1 = List.of(
+        savedUsers.get(3), savedUsers.get(1), savedUsers.get(0), savedUsers.get(2));
+    List<User> orderMatch2 = List.of(
+        savedUsers.get(0), savedUsers.get(2), savedUsers.get(3), savedUsers.get(1));
+
+    Match savedMatch1 = matchRepository.saveMatch(match(null, game, orderMatch1)).orElseThrow();
+    Match savedMatch2 = matchRepository.saveMatch(match(null, game, orderMatch2)).orElseThrow();
+
+    for (int i = 0; i < 2; i++) {
+      Assertions.assertEquals(orderMatch1.stream().map(User::getToken).toList(),
+          matchRepository.findMatchById(savedMatch1.getId()).orElseThrow()
+              .getUsers().stream().map(User::getToken).toList());
+      Assertions.assertEquals(orderMatch2.stream().map(User::getToken).toList(),
+          matchRepository.findMatchById(savedMatch2.getId()).orElseThrow()
+              .getUsers().stream().map(User::getToken).toList());
+    }
+  }
+
+  @Test
+  public void ensureUpdatingAnInvolvedUserKeepsTheMatchUserOrder() {
+    Game game = gameRepository.saveGame(game(null)).orElseThrow();
+    List<User> savedUsers = users(2).stream()
+        .map(u -> userRepository.saveUser(u).orElseThrow())
+        .toList();
+
+    List<User> creationOrder = List.of(savedUsers.get(2), savedUsers.get(0), savedUsers.get(1));
+    Match savedMatch = matchRepository.saveMatch(match(null, game, creationOrder)).orElseThrow();
+
+    User userToRename = savedUsers.get(0);
+    userToRename.setFirstname("Renamed");
+    userRepository.updateUser(userToRename);
+
+    Match rereadMatch = matchRepository.findMatchById(savedMatch.getId()).orElseThrow();
+
+    Assertions.assertEquals(creationOrder.stream().map(User::getToken).toList(),
+        rereadMatch.getUsers().stream().map(User::getToken).toList());
+  }
+
+  @Test
   void ensureFindAllMatchesOrFilteredByGameTokenAndUserTokenReturnsFilteredMatchesForGameTokenAndUserToken() {
     Optional<Game> savedGame = gameRepository.saveGame(game(null));
     Optional<User> savedUser1 = userRepository.saveUser(user(null));


### PR DESCRIPTION
## Summary

The users of a match were mapped as a plain `@ManyToMany List` via the `matches_users` join table — an unordered bag in JPA, so the order in which users came back on a read was whatever the database returned. Since index 0 is treated as the winner by the Elo calculation and the frontend (placement display and win counting), the displayed winner of a historical match could silently differ from the order the rating change was computed from.

- Add `@OrderColumn(name = "user_order", nullable = false)` to `MatchEntity.users`, so the position of every user is persisted and reading a match always returns exactly the creation order
- No API contract change: the `users` array keeps its shape, it just becomes trustworthy
- Migration note documented in the README: the schema is recreated on every startup (`drop-and-create` on in-memory H2), so no pre-migration rows can exist; if the app is ever pointed at a persistent database predating the column, `user_order` must be backfilled before startup

## Tests

- Repository tests: a match created with users in order C, A, B is read back in that order across fresh transactions; interleaved 4-user matches each keep their own order; renaming an involved user leaves the order untouched
- REST integration test: two interleaved 4-user matches created in different orders; repeated fresh GET requests return every match's users in its creation order
- Checked existing suites for tests passing by accident on H2 insertion order — all order-sensitive assertions used single-user matches or mocks, none needed changing

Full `./mvnw clean install` (59 unit tests) and `-Prun-integrationtests` (50 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)