### PR TITLE
fix: LAKWYC-8 throttle failed logins and shrink JWT lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ The `.env` file in the project root is picked up automatically:
 
 Alternatively, export the variables as regular environment variables in your shell — they always take precedence over the `.env` file.
 
+## Login Throttling and Token Lifetime
+
+There is a single, predictable admin account, and the login endpoint is reachable from the
+public internet, so failed logins are throttled per source address: after
+`login.throttle.max-failures` (default 5) failed attempts within
+`login.throttle.window-seconds` (default 900) the source is blocked for
+`login.throttle.lockout-seconds` (default 900). The source is taken from the rightmost
+`X-Forwarded-For` entry (appended by the OpenShift router) or the remote address.
+While blocked, every login attempt is rejected with a generic HTTP 429 **before** any
+password hashing happens — the response does not reveal whether the credentials were
+correct, and a burst of garbage logins cannot burn CPU on the expensive hash.
+Failed and throttled attempts are logged at WARN level with the source address and the
+full `X-Forwarded-For` header, so monitoring can alert on them.
+
+**Token lifetime decision:** JWTs were valid for 12 hours; since there is no revocation
+mechanism, a leaked token would have stayed usable for half a day. The lifetime is
+therefore reduced to **60 minutes** (configurable via `jwt.expiration.minutes`). That is
+short enough to bound the damage of a leaked token and long enough for a normal admin
+session; users simply have to log in again afterwards.
+
 ## Building and Starting the Application
 
 ### Backend (Quarkus)

--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/AuthResourceImplIT.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/impl/AuthResourceImplIT.java
@@ -19,6 +19,7 @@ import java.util.List;
 import static io.restassured.RestAssured.enableLoggingOfRequestAndResponseIfValidationFails;
 import static io.restassured.RestAssured.with;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 public class AuthResourceImplIT {
@@ -103,6 +104,58 @@ public class AuthResourceImplIT {
                 .extract()
                 .path("token");
         usedUserTokens.add(token);
+    }
+
+    @Test
+    public void ensureRepeatedFailedLoginsAreThrottledUniformlyAndRecoverAfterLockout() throws InterruptedException {
+        // TEST-NET source address so the lockout does not affect the other tests,
+        // which are throttled by their real remote address
+        String throttledSource = "203.0.113.7";
+
+        // login.throttle.max-failures=3 (see src/test/resources/application.properties)
+        for (int i = 0; i < 3; i++) {
+            with().when()
+                    .contentType("application/json")
+                    .header("X-Forwarded-For", throttledSource)
+                    .body(new AuthCredentialCommand(SECRET_ADMIN_NAME, "definitely-wrong-password"))
+                    .request("POST", "/auth/login")
+                    .then()
+                    .statusCode(401);
+        }
+
+        // While blocked, wrong and correct credentials get the identical response
+        String throttledBodyWrongPw = with().when()
+                .contentType("application/json")
+                .header("X-Forwarded-For", throttledSource)
+                .body(new AuthCredentialCommand(SECRET_ADMIN_NAME, "definitely-wrong-password"))
+                .request("POST", "/auth/login")
+                .then()
+                .statusCode(429)
+                .extract()
+                .asString();
+
+        String throttledBodyCorrectPw = with().when()
+                .contentType("application/json")
+                .header("X-Forwarded-For", throttledSource)
+                .body(new AuthCredentialCommand(SECRET_ADMIN_NAME, SECRET_DEFAULT_PW))
+                .request("POST", "/auth/login")
+                .then()
+                .statusCode(429)
+                .extract()
+                .asString();
+
+        assertEquals(throttledBodyWrongPw, throttledBodyCorrectPw);
+
+        // After the lockout window (login.throttle.lockout-seconds=3) a correct login succeeds again
+        Thread.sleep(3500);
+
+        with().when()
+                .contentType("application/json")
+                .header("X-Forwarded-For", throttledSource)
+                .body(new AuthCredentialCommand(SECRET_ADMIN_NAME, SECRET_DEFAULT_PW))
+                .request("POST", "/auth/login")
+                .then()
+                .statusCode(200);
     }
 
     @Test

--- a/gamertrack-IntegrationTest/src/test/resources/application.properties
+++ b/gamertrack-IntegrationTest/src/test/resources/application.properties
@@ -7,6 +7,11 @@ quarkus.datasource.username=sa
 quarkus.datasource.password=sa
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
+# Small login-throttle values so the throttling IT completes quickly
+login.throttle.max-failures=3
+login.throttle.window-seconds=60
+login.throttle.lockout-seconds=3
+
 # Test values for the secrets. Real environment variables
 # (SECRET_ADMIN_NAME, SECRET_DEFAULT_PW, SECRET_JWT_HASH,
 # ALLOWED_ORIGINS_AS_REGEX) still take precedence when set.

--- a/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/impl/AuthResourceImpl.java
@@ -1,15 +1,20 @@
 package com.gepardec.rest.impl;
 
 import com.gepardec.core.services.AuthService;
+import com.gepardec.core.services.LoginAttemptService;
 import com.gepardec.rest.api.AuthResource;
 import com.gepardec.rest.model.command.AuthCredentialCommand;
 import com.gepardec.rest.model.command.ValidateTokenCommand;
 import com.gepardec.rest.model.mapper.AuthCredentialRestMapper;
 import com.gepardec.security.JwtUtil;
+import io.vertx.core.http.HttpServerRequest;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 
@@ -17,22 +22,45 @@ import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 @Transactional
 public class AuthResourceImpl implements AuthResource {
 
+    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
+
+    private static final Logger log = LoggerFactory.getLogger(AuthResourceImpl.class);
+
     @Inject
     private AuthService authService;
     @Inject
     private AuthCredentialRestMapper mapper;
     @Inject
     private JwtUtil jwtUtil;
+    @Inject
+    private LoginAttemptService loginAttemptService;
+    @Context
+    HttpServerRequest request;
 
 
     @Override
     public Response login(AuthCredentialCommand authCredentialCommand) {
+        String source = resolveSource();
+
+        // Reject blocked sources before authenticating: the response stays identical for
+        // right and wrong credentials, and no password hashing work is spent on them
+        if (loginAttemptService.isBlocked(source)) {
+            log.warn("Throttled login attempt from {} ({}: {})",
+                    source, X_FORWARDED_FOR, request.getHeader(X_FORWARDED_FOR));
+            return Response.status(Response.Status.TOO_MANY_REQUESTS)
+                    .entity("Too many failed login attempts, try again later").build();
+        }
+
         if (authService.authenticate(mapper.authCredentialCommandToAuthCredential(authCredentialCommand))) {
+            loginAttemptService.loginSucceeded(source);
 
             String token = jwtUtil.generateToken(authCredentialCommand.username());
 
             return Response.ok("{\"token\": \"" + token + "\"}").header(AUTHORIZATION, "Bearer " + token).build();
         } else {
+            loginAttemptService.loginFailed(source);
+            log.warn("Failed login attempt from {} ({}: {})",
+                    source, X_FORWARDED_FOR, request.getHeader(X_FORWARDED_FOR));
             return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid credentials").build();
         }
     }
@@ -42,5 +70,16 @@ public class AuthResourceImpl implements AuthResource {
         if (tokenCmd.token() != null && authService.isTokenValid(tokenCmd.token())) return Response.ok().build();
 
         return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid token").build();
+    }
+
+    // The rightmost X-Forwarded-For entry is the one appended by our OpenShift router;
+    // earlier entries are client-controlled and must not be trusted as the source
+    private String resolveSource() {
+        String forwardedFor = request.getHeader(X_FORWARDED_FOR);
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            String[] hops = forwardedFor.split(",");
+            return hops[hops.length - 1].trim();
+        }
+        return request.remoteAddress() != null ? request.remoteAddress().hostAddress() : "unknown";
     }
 }

--- a/gamertrack-domain/src/main/java/com/gepardec/core/services/LoginAttemptService.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/core/services/LoginAttemptService.java
@@ -1,0 +1,10 @@
+package com.gepardec.core.services;
+
+public interface LoginAttemptService {
+
+    boolean isBlocked(String source);
+
+    void loginFailed(String source);
+
+    void loginSucceeded(String source);
+}

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/LoginAttemptServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/LoginAttemptServiceImpl.java
@@ -1,0 +1,89 @@
+package com.gepardec.impl.service;
+
+import com.gepardec.core.services.LoginAttemptService;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+@ApplicationScoped
+public class LoginAttemptServiceImpl implements LoginAttemptService {
+
+    private static final Logger log = LoggerFactory.getLogger(LoginAttemptServiceImpl.class);
+
+    // Bounds the tracked sources so a distributed attack cannot exhaust memory
+    static final int MAX_TRACKED_SOURCES = 10_000;
+
+    @ConfigProperty(name = "login.throttle.max-failures", defaultValue = "5")
+    int maxFailures;
+    @ConfigProperty(name = "login.throttle.window-seconds", defaultValue = "900")
+    long windowSeconds;
+    @ConfigProperty(name = "login.throttle.lockout-seconds", defaultValue = "900")
+    long lockoutSeconds;
+
+    // Overridable in tests so lockout expiry can be tested without sleeping
+    LongSupplier currentTimeMillis = System::currentTimeMillis;
+
+    private final ConcurrentHashMap<String, SourceState> attemptsBySource = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean isBlocked(String source) {
+        SourceState state = attemptsBySource.get(source);
+        return state != null && state.isBlockedAt(currentTimeMillis.getAsLong());
+    }
+
+    @Override
+    public void loginFailed(String source) {
+        long now = currentTimeMillis.getAsLong();
+        pruneExpiredIfOverCapacity(now);
+        SourceState state = attemptsBySource.computeIfAbsent(source, key -> new SourceState());
+        if (state.recordFailure(now, windowSeconds * 1000, maxFailures, lockoutSeconds * 1000)) {
+            log.warn("Login source {} blocked for {} seconds after {} failed attempts within {} seconds",
+                    source, lockoutSeconds, maxFailures, windowSeconds);
+        }
+    }
+
+    @Override
+    public void loginSucceeded(String source) {
+        attemptsBySource.remove(source);
+    }
+
+    private void pruneExpiredIfOverCapacity(long now) {
+        if (attemptsBySource.size() > MAX_TRACKED_SOURCES) {
+            attemptsBySource.entrySet().removeIf(entry -> entry.getValue().isExpiredAt(now, windowSeconds * 1000));
+        }
+    }
+
+    static final class SourceState {
+
+        private final Deque<Long> failureTimes = new ArrayDeque<>();
+        private long blockedUntil;
+
+        synchronized boolean isBlockedAt(long now) {
+            return now < blockedUntil;
+        }
+
+        synchronized boolean recordFailure(long now, long windowMillis, int maxFailures, long lockoutMillis) {
+            failureTimes.addLast(now);
+            while (!failureTimes.isEmpty() && failureTimes.peekFirst() <= now - windowMillis) {
+                failureTimes.removeFirst();
+            }
+            if (failureTimes.size() >= maxFailures && now >= blockedUntil) {
+                blockedUntil = now + lockoutMillis;
+                failureTimes.clear();
+                return true;
+            }
+            return false;
+        }
+
+        synchronized boolean isExpiredAt(long now, long windowMillis) {
+            return now >= blockedUntil
+                    && (failureTimes.isEmpty() || failureTimes.peekLast() <= now - windowMillis);
+        }
+    }
+}

--- a/gamertrack-domain/src/main/java/com/gepardec/security/JwtUtil.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/security/JwtUtil.java
@@ -20,11 +20,14 @@ public class JwtUtil {
     @ConfigProperty(name = "secret.jwt.hash")
     String SECRET_KEY;
 
+    @ConfigProperty(name = "jwt.expiration.minutes", defaultValue = "60")
+    long JWT_EXPIRATION_MINUTES;
+
     public String generateToken(String username) {
         var jwt = Jwts.builder()
                 .setSubject(username)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 720))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * JWT_EXPIRATION_MINUTES))
                 .signWith(SignatureAlgorithm.HS512, generateKey())
                 .compact();
 

--- a/gamertrack-domain/src/test/java/com/gepardec/impl/service/LoginAttemptServiceImplTest.java
+++ b/gamertrack-domain/src/test/java/com/gepardec/impl/service/LoginAttemptServiceImplTest.java
@@ -1,0 +1,96 @@
+package com.gepardec.impl.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LoginAttemptServiceImplTest {
+
+    static final String SOURCE = "203.0.113.7";
+
+    LoginAttemptServiceImpl loginAttemptService;
+    long now;
+
+    @BeforeEach
+    void setup() {
+        loginAttemptService = new LoginAttemptServiceImpl();
+        loginAttemptService.maxFailures = 3;
+        loginAttemptService.windowSeconds = 60;
+        loginAttemptService.lockoutSeconds = 300;
+        loginAttemptService.currentTimeMillis = () -> now;
+        now = 0;
+    }
+
+    @Test
+    void ensureSourceIsNotBlockedWithoutFailures() {
+        assertFalse(loginAttemptService.isBlocked(SOURCE));
+    }
+
+    @Test
+    void ensureSourceIsNotBlockedBelowMaxFailures() {
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        assertFalse(loginAttemptService.isBlocked(SOURCE));
+    }
+
+    @Test
+    void ensureSourceIsBlockedAfterMaxFailuresWithinWindow() {
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        assertTrue(loginAttemptService.isBlocked(SOURCE));
+    }
+
+    @Test
+    void ensureFailuresOutsideWindowDoNotCountTowardsBlocking() {
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        now = 61_000;
+        loginAttemptService.loginFailed(SOURCE);
+        assertFalse(loginAttemptService.isBlocked(SOURCE));
+    }
+
+    @Test
+    void ensureBlockExpiresAfterLockout() {
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+
+        now = 299_999;
+        assertTrue(loginAttemptService.isBlocked(SOURCE));
+        now = 300_000;
+        assertFalse(loginAttemptService.isBlocked(SOURCE));
+    }
+
+    @Test
+    void ensureFailureCountRestartsAfterLockoutExpired() {
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+
+        now = 300_000;
+        loginAttemptService.loginFailed(SOURCE);
+        assertFalse(loginAttemptService.isBlocked(SOURCE));
+    }
+
+    @Test
+    void ensureSuccessfulLoginResetsFailures() {
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginSucceeded(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        assertFalse(loginAttemptService.isBlocked(SOURCE));
+    }
+
+    @Test
+    void ensureSourcesAreBlockedIndependently() {
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        loginAttemptService.loginFailed(SOURCE);
+        assertTrue(loginAttemptService.isBlocked(SOURCE));
+        assertFalse(loginAttemptService.isBlocked("198.51.100.1"));
+    }
+}

--- a/gamertrack-war/src/main/resources/application.properties
+++ b/gamertrack-war/src/main/resources/application.properties
@@ -7,6 +7,12 @@ quarkus.datasource.username=sa
 quarkus.datasource.password=sa
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
+# Login throttling: after max-failures failed logins within the window,
+# the source address is blocked for lockout-seconds
+login.throttle.max-failures=5
+login.throttle.window-seconds=900
+login.throttle.lockout-seconds=900
+
 # Secrets provided via environment variables or a .env file
 # in the working directory the application is started from
 # (dev mode runs from the project root, see workingDir in pom.xml)

--- a/gamertrack-war/src/main/resources/application.properties
+++ b/gamertrack-war/src/main/resources/application.properties
@@ -13,6 +13,10 @@ login.throttle.max-failures=5
 login.throttle.window-seconds=900
 login.throttle.lockout-seconds=900
 
+# Token lifetime: no revocation mechanism exists, so tokens stay short-lived
+# (see "Login Throttling and Token Lifetime" in the README)
+jwt.expiration.minutes=60
+
 # Secrets provided via environment variables or a .env file
 # in the working directory the application is started from
 # (dev mode runs from the project root, see workingDir in pom.xml)


### PR DESCRIPTION
## Summary
- Throttle failed login attempts per source address: after `login.throttle.max-failures` (default 5) failures within `login.throttle.window-seconds` (default 900), the source is blocked for `login.throttle.lockout-seconds` (default 900)
- Blocked attempts are rejected with a generic HTTP 429 **before** any password hashing, so the response leaks nothing about credential correctness and garbage bursts cannot burn CPU on the 210k-iteration hash
- Source is the rightmost `X-Forwarded-For` entry (appended by the OpenShift router, not client-forgeable) with fallback to the remote address; failed and throttled attempts are logged at WARN with source info for monitoring
- JWT lifetime reduced from hardcoded 12 hours to 60 minutes, configurable via `jwt.expiration.minutes`; decision documented in the README (no revocation exists, so leak damage must be time-bounded)

## Test plan
- Unit tests for `LoginAttemptServiceImpl` (window pruning, lockout expiry, reset on success, per-source independence) — `./mvnw install`, 84 tests green
- Integration test: 3 failed logins → identical 429 body for wrong and correct password → correct login succeeds after lockout — `./mvnw verify -Prun-integrationtests`, all 50 ITs green

## Notes
- Session UX change: with no refresh mechanism, admins must log in again after 60 minutes. If that is too aggressive, `jwt.expiration.minutes` is a one-line config change; sliding renewal was discussed but deliberately left out of scope.

Fixes LAKWYC-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)