### PR TITLE
LAKWYC-9: never log Authorization headers, JWTs or configured secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ The `.env` file in the project root is picked up automatically:
 
 Alternatively, export the variables as regular environment variables in your shell — they always take precedence over the `.env` file.
 
+## Contributing: Never Log Secrets
+
+Tokens, passwords and secrets never go into log statements. This includes
+Authorization header values, JWTs (even expired or malformed ones — they are
+often valid or reusable credentials), user passwords and any value configured
+via the `SECRET_*` environment variables. Log the fact and the shape of a
+failure instead (e.g. "expired", "invalid signature", "missing header"); for
+correlation use at most a short non-reversible fingerprint via
+`com.gepardec.security.TokenLogUtil.fingerprint(...)`. The integration test
+`AuthFilterLoggingIT` sweeps the application log for token material.
+
 ## Building and Starting the Application
 
 ### Backend (Quarkus)

--- a/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/config/AuthFilterLoggingIT.java
+++ b/gamertrack-IntegrationTest/src/test/java/com/gepardec/rest/config/AuthFilterLoggingIT.java
@@ -1,0 +1,235 @@
+package com.gepardec.rest.config;
+
+import com.gepardec.rest.model.command.AuthCredentialCommand;
+import com.gepardec.rest.model.command.CreateUserCommand;
+import com.gepardec.security.JwtUtil;
+import io.jsonwebtoken.Jwts;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static io.restassured.RestAssured.with;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * LAKWYC-9: authentication failures must be logged without the credential
+ * material itself (Authorization header value, JWT token). These tests
+ * capture everything the application logs below com.gepardec and sweep it
+ * for token material.
+ */
+@QuarkusTest
+public class AuthFilterLoggingIT {
+
+    private static final Logger APP_LOGGER = Logger.getLogger("com.gepardec");
+    private static final CapturingLogHandler capturedLogs = new CapturingLogHandler();
+
+    @Inject
+    JwtUtil jwtUtil;
+
+    @ConfigProperty(name = "secret.default.pw")
+    String SECRET_DEFAULT_PW;
+    @ConfigProperty(name = "secret.admin.name")
+    String SECRET_ADMIN_NAME;
+
+    @BeforeAll
+    public static void attachLogHandler() {
+        APP_LOGGER.addHandler(capturedLogs);
+    }
+
+    @AfterAll
+    public static void detachLogHandler() {
+        APP_LOGGER.removeHandler(capturedLogs);
+    }
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.basePath = "/gepardec-gamertrack/api/v1";
+        capturedLogs.clear();
+    }
+
+    @Test
+    public void malformedAuthorizationHeaderIsRejectedWithoutLoggingItsValue() {
+        String headerValue = "Basic bWF4Om11c3RlcnBhc3N3b3Jk";
+
+        requestUserCreation(headerValue)
+                .then()
+                .statusCode(401);
+
+        String logText = capturedLogs.text();
+        assertTrue(logText.contains("does not use the Bearer scheme"),
+                "log should state the failure reason");
+        assertFalse(logText.contains("bWF4Om11c3RlcnBhc3N3b3Jk"),
+                "log must not contain the Authorization header value");
+    }
+
+    @Test
+    public void missingAuthorizationHeaderIsRejectedWithReasonInLog() {
+        with().when()
+                .contentType("application/json")
+                .body(new CreateUserCommand("max", "Muster"))
+                .request("POST", "/users")
+                .then()
+                .statusCode(401);
+
+        assertTrue(capturedLogs.text().contains("no Authorization header provided"),
+                "log should state the failure reason");
+    }
+
+    @Test
+    public void expiredTokenIsRejectedWithCategoryButWithoutToken() {
+        String expiredToken = Jwts.builder()
+                .subject(SECRET_ADMIN_NAME)
+                .issuedAt(new Date(System.currentTimeMillis() - 20_000))
+                .expiration(new Date(System.currentTimeMillis() - 10_000))
+                .signWith(jwtUtil.generateKey())
+                .compact();
+
+        requestUserCreation("Bearer " + expiredToken)
+                .then()
+                .statusCode(401);
+
+        String logText = capturedLogs.text();
+        assertTrue(logText.contains("expired"),
+                "log should carry the failure category");
+        assertLogFreeOfTokenMaterial(logText, expiredToken);
+    }
+
+    @Test
+    public void garbageTokenIsRejectedWithoutLoggingIt() {
+        String garbageToken = "aksldfjalsdfjalskdjfaksdl.asdfasddfasdf.asdfsadff";
+
+        requestUserCreation("Bearer " + garbageToken)
+                .then()
+                .statusCode(401);
+
+        assertLogFreeOfTokenMaterial(capturedLogs.text(), garbageToken);
+    }
+
+    @Test
+    public void successfulAuthenticationLogsNeitherTokenNorCredentials() {
+        String token = with().when()
+                .contentType("application/json")
+                .body(new AuthCredentialCommand(SECRET_ADMIN_NAME, SECRET_DEFAULT_PW))
+                .headers("Content-Type", ContentType.JSON,
+                        "Accept", ContentType.JSON)
+                .request("POST", "/auth/login")
+                .then()
+                .statusCode(200)
+                .extract()
+                .header("Authorization")
+                .replace("Bearer ", "");
+
+        String userToken = requestUserCreation("Bearer " + token)
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("token");
+
+        with().headers("Authorization", "Bearer " + token)
+                .when()
+                .contentType("application/json")
+                .pathParam("token", userToken)
+                .request("DELETE", "/users/{token}");
+
+        String logText = capturedLogs.text();
+        assertTrue(logText.contains("Successfully authenticated user"));
+        assertLogFreeOfTokenMaterial(logText, token);
+        assertFalse(logText.contains(SECRET_DEFAULT_PW),
+                "log must not contain the configured password");
+    }
+
+    private io.restassured.response.Response requestUserCreation(String authorizationHeader) {
+        return with().when()
+                .contentType("application/json")
+                .body(new CreateUserCommand("max", "Muster"))
+                .headers(
+                        "Authorization",
+                        authorizationHeader,
+                        "Content-Type",
+                        ContentType.JSON,
+                        "Accept",
+                        ContentType.JSON)
+                .request("POST", "/users");
+    }
+
+    /**
+     * The full token must be absent, and so must its individual segments:
+     * header and payload of an expired but otherwise valid token are
+     * reusable material.
+     */
+    private void assertLogFreeOfTokenMaterial(String logText, String token) {
+        for (String line : capturedLogs.records()) {
+            assertFalse(line.contains(token),
+                    "log must not contain the token, but this line does: " + line);
+            for (String segment : token.split("\\.")) {
+                assertFalse(line.contains(segment),
+                        "log must not contain any token segment, but this line does: " + line);
+            }
+        }
+    }
+
+    /**
+     * Captures raw log records (message, parameters and stack traces) below
+     * the attached logger so tests can sweep them for credential material.
+     */
+    private static final class CapturingLogHandler extends Handler {
+
+        private final List<String> lines = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            StringBuilder line = new StringBuilder();
+            line.append('[').append(record.getLoggerName()).append("] ");
+            if (record.getMessage() != null) {
+                line.append(record.getMessage());
+            }
+            if (record.getParameters() != null) {
+                for (Object parameter : record.getParameters()) {
+                    line.append(' ').append(parameter);
+                }
+            }
+            if (record.getThrown() != null) {
+                StringWriter stackTrace = new StringWriter();
+                record.getThrown().printStackTrace(new PrintWriter(stackTrace));
+                line.append(' ').append(stackTrace);
+            }
+            lines.add(line.toString());
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        void clear() {
+            lines.clear();
+        }
+
+        List<String> records() {
+            return lines;
+        }
+
+        String text() {
+            return String.join(System.lineSeparator(), lines);
+        }
+    }
+}

--- a/gamertrack-application/src/main/java/com/gepardec/rest/config/AuthFilter.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/config/AuthFilter.java
@@ -1,6 +1,7 @@
 package com.gepardec.rest.config;
 
 import com.gepardec.security.JwtUtil;
+import com.gepardec.security.TokenLogUtil;
 import io.jsonwebtoken.Jwts;
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
@@ -37,7 +38,10 @@ public class AuthFilter implements ContainerRequestFilter {
 
         String authHeader = reqCtx.getHeaderString(HttpHeaders.AUTHORIZATION);
         if (authHeader == null || !authHeader.startsWith(BEARER)) {
-            log.info("Authorization header is invalid {}", authHeader);
+            // Never log the header value itself, it may contain a valid credential
+            log.info("Authorization rejected: {}", authHeader == null
+                    ? "no Authorization header provided"
+                    : "Authorization header does not use the Bearer scheme");
 
             throw new NotAuthorizedException("No authorization header provided");
         }
@@ -72,7 +76,10 @@ public class AuthFilter implements ContainerRequestFilter {
             log.info("Successfully authenticated user");
 
         } catch (Exception e) {
-            log.error("Invalid JWT token {}", token, e);
+            // Log only the failure category and a non-reversible fingerprint,
+            // never the token itself
+            log.error("Invalid JWT token ({}), fingerprint {}",
+                    TokenLogUtil.categorize(e), TokenLogUtil.fingerprint(token));
             reqCtx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
         }
     }

--- a/gamertrack-application/src/main/java/com/gepardec/rest/config/filters/request/LoggingRequestFilter.java
+++ b/gamertrack-application/src/main/java/com/gepardec/rest/config/filters/request/LoggingRequestFilter.java
@@ -2,6 +2,7 @@ package com.gepardec.rest.config.filters.request;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.ext.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +48,9 @@ public class LoggingRequestFilter implements ContainerRequestFilter {
                 .forEach((k, v) ->
                 {
                     v.forEach(value -> tmp.set(tmp + value));
-                    sb.append("\t\t%s:\t%s\n".formatted(k, tmp.get()));
+                    // Never log credential material (LAKWYC-9)
+                    sb.append("\t\t%s:\t%s\n".formatted(k,
+                            HttpHeaders.AUTHORIZATION.equalsIgnoreCase(k) ? "[redacted]" : tmp.get()));
                     tmp.set("");
                 });
 

--- a/gamertrack-domain/src/main/java/com/gepardec/impl/service/AuthServiceImpl.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/impl/service/AuthServiceImpl.java
@@ -5,6 +5,7 @@ import com.gepardec.core.services.AuthService;
 import com.gepardec.core.services.TokenService;
 import com.gepardec.model.AuthCredential;
 import com.gepardec.security.JwtUtil;
+import com.gepardec.security.TokenLogUtil;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -41,7 +42,8 @@ public class AuthServiceImpl implements AuthService {
 
             if (dbCredential.isPresent()){
                 if(jwtUtil.passwordsMatches(dbCredential.get().getPassword(), dbCredential.get().getSalt(), credential.getPassword())){
-                    log.info("Credential {} authenticated", credential.getUsername());
+                    // The admin username is a configured secret, never log it
+                    log.info("Credential authenticated");
                     return true;
                 }
                 log.error("Invalid credential: Credential dont match");
@@ -77,7 +79,8 @@ public class AuthServiceImpl implements AuthService {
             Jwts.parser().setSigningKey(jwtUtil.generateKey()).build().parseClaimsJws(token);
             isValid = true;
         } catch (JwtException e) {
-            log.error("Token validation failed {}", e.getMessage());
+            log.error("Token validation failed ({}), fingerprint {}",
+                    TokenLogUtil.categorize(e), TokenLogUtil.fingerprint(token));
         }
         return isValid;
     }

--- a/gamertrack-domain/src/main/java/com/gepardec/security/TokenLogUtil.java
+++ b/gamertrack-domain/src/main/java/com/gepardec/security/TokenLogUtil.java
@@ -1,0 +1,65 @@
+package com.gepardec.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Helpers for logging authentication failures without writing credential
+ * material (Authorization headers, JWTs, passwords, configured secrets)
+ * into the log.
+ */
+public final class TokenLogUtil {
+
+    private static final int FINGERPRINT_LENGTH = 8;
+
+    private TokenLogUtil() {
+    }
+
+    /**
+     * Maps a JWT parsing/validation exception to a short failure category
+     * that is safe to log. Never returns token or claim contents.
+     */
+    public static String categorize(Exception e) {
+        if (e instanceof ExpiredJwtException) {
+            return "expired";
+        }
+        if (e instanceof SignatureException) {
+            return "invalid signature";
+        }
+        if (e instanceof MalformedJwtException) {
+            return "malformed";
+        }
+        if (e instanceof UnsupportedJwtException) {
+            return "unsupported";
+        }
+        if (e instanceof IllegalArgumentException) {
+            return "missing or blank token";
+        }
+        return e.getClass().getSimpleName();
+    }
+
+    /**
+     * Short non-reversible fingerprint (first {@value FINGERPRINT_LENGTH}
+     * hex chars of a SHA-256 hash) so log entries can be correlated to a
+     * token without exposing it.
+     */
+    public static String fingerprint(String token) {
+        if (token == null || token.isBlank()) {
+            return "n/a";
+        }
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256")
+                    .digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash).substring(0, FINGERPRINT_LENGTH);
+        } catch (NoSuchAlgorithmException e) {
+            return "n/a";
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.5.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
## Summary

Fixes LAKWYC-9: authentication logs no longer contain credential material. Failure logs carry a categorized reason (missing header, wrong scheme, expired, invalid signature, malformed, …) plus a short non-reversible SHA-256 fingerprint for correlation instead of the header/token value itself.

- **`AuthFilter`**: stopped logging the Authorization header value and the full JWT; introduced `com.gepardec.security.TokenLogUtil` for failure categorization and fingerprinting.
- **`AuthServiceImpl`**: the successful-login message logged the username — for the default user that is the configured secret `secret.admin.name`; token validation logged the raw `JwtException` message, which can echo token fragments. Both now log only safe category/fingerprint information.
- **`LoggingRequestFilter`** (found by the new log-sweep test): logged every request's complete header set at INFO, so every authenticated call wrote its bearer token to the log. The Authorization header is now rendered as `[redacted]`.
- Repository/service logging of user/game/score "tokens" refers to business entity identifiers, not credentials, and is intentionally unchanged.

## Tests

- New `AuthFilterLoggingIT` captures all log records below `com.gepardec` (messages, parameters and stack traces) and sweeps them for the header value, the full JWT and each JWT segment across five scenarios: malformed header, missing header, expired token, garbage token and successful authentication — each also asserting unchanged 401/200 behavior.
- Enabling that required setting `java.util.logging.manager=org.jboss.logmanager.LogManager` for failsafe (it was only configured for surefire), so `@QuarkusTest` ITs can observe application log records at all.
- Full run: `./mvnw clean install` + `./mvnw verify -Prun-integrationtests` → BUILD SUCCESS, 54 ITs, 0 failures. Grepping the entire run output for the HS512 JWT prefix of every issued token (`eyJhbGciOiJIUzUxMiJ9`) and for the configured password: zero hits.

## Docs

- README gained a "Contributing: Never Log Secrets" section: tokens, passwords and `SECRET_*` values never go into log statements; use `TokenLogUtil.fingerprint(...)` for correlation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)